### PR TITLE
Create a mission as the final step in the preparations

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -42,6 +42,11 @@ if __name__ == "__main__":
     for participant in participant_services:
         participant.setup()
 
+    for participant in participant_services:
+        runner.create_mission(participant.smm)
+
+    print("Ready. Lets go")
+
     # Run the IMT Challenge
     time.sleep(120)
 

--- a/mission.py
+++ b/mission.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from smm_client.organizations import SMMOrganization
+from smm_client.types import SMMPoint
 from services.helpers import get_random_string
 from configloader import load_config
 
@@ -94,3 +95,30 @@ class MissionRunner:
                 org_asset_user = SMMOrganization(smm_asset, organization.id, organization.name)
                 org_asset_user.add_asset(asset_smm)
                 organization.add_member(asset_smm_account, role='M')
+
+    def create_mission(self, smm: SMMServer) -> None:
+        """
+        Create the mission and populate it with the starting data
+        """
+        smm_imt_challenge = smm.get_web_connection('imt-challenge', self.runner_password)
+        mission = smm_imt_challenge.create_mission(self.config['name'], self.config['description'])
+        if 'POIs' in self.config:
+            for poi in self.config['POIs']:
+                if not isinstance(poi, dict):
+                    continue
+                location = poi.get('location')
+                if not isinstance(location, dict):
+                    continue
+                point = None
+                if 'latitude' in location and 'longitude' in location:
+                    point = SMMPoint(location['latitude'], location['longitude'])
+                name = poi.get('name')
+                if point is not None and name is not None:
+                    mission.add_waypoint(point, name)
+        organisations = smm_imt_challenge.get_organizations(all_orgs=True)
+        for organisation in organisations:
+            if organisation.name == 'IMT':
+                mission_org = mission.add_organization(organisation)
+                # Make it so the IMT members can add other organizations to the mission
+                # Adding an organization is the trigger event to activate the related asset(s)
+                mission_org.set_can_add_organizations(value=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # run-time depends
 docker==7.1.0
-smm-client==0.0.2
+smm-client==0.0.4
 PyYAML==6.0.2
 
 # code checking


### PR DESCRIPTION
Requires smm-client 0.0.4 to give the IMT members permissions to add other organizations

Populates the mission with any POIs from the config

## Summary by Sourcery

Add functionality to create a mission with initial data, including POIs, and update smm-client to version 0.0.4 to allow IMT members to add other organizations.

New Features:
- Introduce a new method to create a mission and populate it with starting data, including points of interest (POIs) from the configuration.

Enhancements:
- Update the smm-client dependency to version 0.0.4 to enable new permissions for IMT members.