### PR TITLE
Mission add assets

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -55,7 +55,10 @@ if __name__ == "__main__":
     print("Ready. Lets go")
 
     # Run the IMT Challenge
-    time.sleep(120)
+    start_time = time.time()
+    while time.time() - start_time < 120:
+        time.sleep(1)
+        runner.time_tick()
 
     for participant in participant_services:
         participant.cleanup()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # run-time depends
 docker==7.1.0
-smm-client==0.0.5
+smm-client==0.0.7
 PyYAML==6.0.2
 
 # code checking


### PR DESCRIPTION
Add assets to the mission in response to the user adding the organization related to the asset

## Summary by Sourcery

Add support for adding assets to a mission in response to new organizations being added to the mission.

New Features:
- Assets are automatically added to a mission when a related organization is added.

Tests:
- Updated tests to reflect the new functionality.