### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -2,6 +2,8 @@ name: Run Check Code
 
 on: pull_request
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/imt-challenge/imt-challenge-runner/security/code-scanning/1](https://github.com/imt-challenge/imt-challenge-runner/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. Since the workflow only checks out code and runs scripts, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`), which will apply to all jobs unless overridden. This change should be made in `.github/workflows/checkcode.yml`, above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a permissions block to .github/workflows/checkcode.yml to grant read-only access to repository contents via GITHUB_TOKEN