### PR TITLE
Guarantee container and network cleanup on every exit path

### DIFF
--- a/instance.py
+++ b/instance.py
@@ -49,10 +49,14 @@ class Participant:
         """
         Stop the services for this participant
         """
-        self.smm.stop()
+        if self.smm is not None:
+            self.smm.stop()
 
     def cleanup(self) -> None:
         """
-        Cleanup the services for this participant
+        Cleanup the services for this participant.
+        Safe to call if start() was never reached or only partially succeeded.
         """
-        self.smm.cleanup()
+        if self.smm is not None:
+            self.smm.cleanup()
+            self.smm = None

--- a/letsgo.py
+++ b/letsgo.py
@@ -4,6 +4,8 @@ Start an IMT Challenge based on a config file
 """
 
 import argparse
+import contextlib
+import signal
 import time
 
 import docker
@@ -24,6 +26,13 @@ def arg_is_positive(value) -> int:
     if ivalue <= 0:
         raise argparse.ArgumentTypeError(f"{value} must be positive")
     return ivalue
+
+
+def _install_signal_handlers() -> None:
+    def _handle(signum, _frame):
+        raise KeyboardInterrupt(f"Received signal {signum}")
+    signal.signal(signal.SIGINT, _handle)
+    signal.signal(signal.SIGTERM, _handle)
 
 
 if __name__ == "__main__":
@@ -49,8 +58,14 @@ if __name__ == "__main__":
         required=True,
         action='append',
         help='load participant details from file')
+    parser.add_argument(
+        '--keep',
+        action='store_true',
+        help='Skip teardown on exit so the operator can inspect state')
 
     args = parser.parse_args()
+
+    _install_signal_handlers()
 
     docker_client = docker.from_env()
 
@@ -60,32 +75,38 @@ if __name__ == "__main__":
         Participant(participant) for participant in args.participant
     ]
 
-    # Start all the services
-    for participant in participant_services:
-        participant.start(docker_client)
+    with contextlib.ExitStack() as cleanup_stack:
+        if not args.keep:
+            # ExitStack unwinds in reverse, so register participant cleanup
+            # first and runner.stop last — vehicle containers must go before
+            # the SMM networks they are attached to.
+            for participant in participant_services:
+                cleanup_stack.callback(participant.cleanup)
+            cleanup_stack.callback(runner.stop)
 
-    # Add each participant to the runner
-    for participant in participant_services:
-        runner.add_participant(participant.smm)
+        # Start all the services
+        for participant in participant_services:
+            participant.start(docker_client)
 
-    # Setup the participants in their server
-    for participant in participant_services:
-        participant.setup()
+        # Add each participant to the runner
+        for participant in participant_services:
+            runner.add_participant(participant.smm)
 
-    runner.create_mission()
+        # Setup the participants in their server
+        for participant in participant_services:
+            participant.setup()
 
-    for participant in participant_services:
-        print(f"{participant.name}: http://localhost:{participant.smm.port}")
+        runner.create_mission()
 
-    print("Ready. Lets go")
+        for participant in participant_services:
+            print(
+                f"{participant.name}: "
+                f"http://localhost:{participant.smm.port}")
 
-    # Run the IMT Challenge
-    start_time = time.time()
-    while time.time() - start_time < args.time:
-        time.sleep(1)
-        runner.time_tick()
+        print("Ready. Lets go")
 
-    runner.stop()
-
-    for participant in participant_services:
-        participant.cleanup()
+        # Run the IMT Challenge
+        start_time = time.time()
+        while time.time() - start_time < args.time:
+            time.sleep(1)
+            runner.time_tick()

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -5,6 +5,37 @@ String helpers
 import random
 import string
 
+import docker
+import docker.errors
+
+
+def remove_container(container) -> None:
+    """
+    Force-remove a docker container, tolerating a container that was
+    never started or has already been removed.
+    """
+    if container is None:
+        return
+    try:
+        container.remove(force=True)
+    except docker.errors.NotFound:
+        pass
+
+
+def remove_network(network) -> None:
+    """
+    Remove a docker network, tolerating networks that have already been
+    removed or still have endpoints attached.
+    """
+    if network is None:
+        return
+    try:
+        network.remove()
+    except docker.errors.NotFound:
+        pass
+    except docker.errors.APIError as exc:
+        print(f"Skipping removal of network {network.name}: {exc}")
+
 
 def get_random_string(length) -> str:
     """

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -4,7 +4,10 @@ Postgres server
 
 import time
 
-from .helpers import get_random_string
+import docker
+import docker.errors
+
+from .helpers import get_random_string, remove_container
 
 
 class PostgresServer:
@@ -16,6 +19,7 @@ class PostgresServer:
         self.postgres_pass = get_random_string(10)
         self.name = name
         self._db_name = db_name
+        self.instance = None
         docker_client.images.pull('postgis/postgis:17-3.5')
         self.instance = docker_client.containers.create(
             'postgis/postgis:17-3.5',
@@ -55,11 +59,17 @@ class PostgresServer:
         """
         Stop this instance
         """
-        self.instance.stop()
+        if self.instance is None:
+            return
+        try:
+            self.instance.stop()
+        except (docker.errors.NotFound, docker.errors.APIError):
+            pass
 
     def cleanup(self) -> None:
         """
-        Cleanup from running this instance
+        Cleanup from running this instance.
+        Safe to call even if start() was never reached.
         """
-        self.stop()
-        self.instance.remove()
+        remove_container(self.instance)
+        self.instance = None

--- a/services/smm.py
+++ b/services/smm.py
@@ -12,7 +12,7 @@ import docker.errors
 from smm_client.connection import SMMConnection
 
 from .postgres import PostgresServer
-from .helpers import get_random_string
+from .helpers import get_random_string, remove_container, remove_network
 
 
 class SMMServer:
@@ -25,6 +25,9 @@ class SMMServer:
         self.name = name
         self.external_network = network
         self.internal_port = 8080
+        self.db_net = None
+        self.postgres = None
+        self.instance = None
         try:
             self.db_net = docker_client.networks.get(f'{name}-net')
         except docker.errors.NotFound:
@@ -82,17 +85,26 @@ class SMMServer:
         """
         Stop this instance, and the related database server
         """
-        self.instance.stop()
-        self.postgres.stop()
+        if self.instance is not None:
+            try:
+                self.instance.stop()
+            except (docker.errors.NotFound, docker.errors.APIError):
+                pass
+        if self.postgres is not None:
+            self.postgres.stop()
 
     def cleanup(self) -> None:
         """
-        Cleanup from running this instance
+        Cleanup from running this instance.
+        Idempotent and tolerant of partial/failed starts.
         """
-        self.stop()
-        self.instance.remove()
-        self.postgres.cleanup()
-        self.db_net.remove()
+        remove_container(self.instance)
+        self.instance = None
+        if self.postgres is not None:
+            self.postgres.cleanup()
+            self.postgres = None
+        remove_network(self.db_net)
+        self.db_net = None
 
     def get_web_connection(
             self,

--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -4,8 +4,10 @@ Vehicles
 import random
 
 import docker
+import docker.errors
 
-from services.helpers import sanitize_account_name
+from services.helpers import (
+    remove_container, remove_network, sanitize_account_name)
 
 
 class Vehicle:
@@ -96,8 +98,12 @@ class Vehicle:
 
     def stop(self):
         """
-        Stop the vehicle
+        Stop and tear down the vehicle containers and their private network.
+        Idempotent and tolerant of containers that never started or are
+        already removed.
         """
-        self.smm_mavlink.stop()
-        self.mavproxy.stop()
-        self.apm.stop()
+        for attr in ('smm_mavlink', 'mavproxy', 'apm'):
+            remove_container(getattr(self, attr, None))
+            setattr(self, attr, None)
+        remove_network(self.net)
+        self.net = None


### PR DESCRIPTION
Wrap the letsgo.py lifecycle in contextlib.ExitStack and install SIGINT/SIGTERM handlers that raise KeyboardInterrupt, so Ctrl-C or a mid-run exception no longer leaks SMM, postgres, or SITL containers and their networks. Make SMMServer, PostgresServer, Vehicle, and Participant cleanup idempotent and tolerant of partial starts, and add a --keep flag for debugging failed runs.

## Summary by Sourcery

Ensure mission runner and related Docker services clean up containers and networks reliably on all exit paths, including interrupts and partial starts.

New Features:
- Add a --keep flag to allow skipping teardown for debugging failed runs.
- Install SIGINT/SIGTERM handlers so Ctrl-C triggers controlled shutdown via KeyboardInterrupt.

Enhancements:
- Wrap the main runner lifecycle in an ExitStack to centralize and order teardown callbacks.
- Make SMMServer, PostgresServer, Vehicle, and Participant cleanup and stop operations idempotent and tolerant of partially started resources.
- Introduce shared helper functions for safely removing Docker containers and networks, including handling missing or attached resources.