### PR TITLE
Probe real readiness for postgres and SMM with bounded timeouts

### DIFF
--- a/services/helpers.py
+++ b/services/helpers.py
@@ -4,6 +4,8 @@ String helpers
 
 import random
 import string
+import time
+from typing import Callable
 
 import docker
 import docker.errors
@@ -43,6 +45,27 @@ def get_random_string(length) -> str:
     """
     return ''.join(
         random.choice(string.ascii_lowercase) for _ in range(length))
+
+
+def wait_until(
+        predicate: Callable[[], bool],
+        timeout: float = 120.0,
+        interval: float = 1.0,
+        description: str = "condition") -> None:
+    """
+    Poll `predicate()` until it returns truthy, or raise TimeoutError
+    once `timeout` seconds have elapsed. Sleeps `interval` seconds
+    between polls.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if predicate():
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Timed out after {timeout:.0f}s waiting for {description}")
+        time.sleep(min(interval, remaining))
 
 
 def sanitize_account_name(account: str) -> str:

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -2,12 +2,10 @@
 Postgres server
 """
 
-import time
-
 import docker
 import docker.errors
 
-from .helpers import get_random_string, remove_container
+from .helpers import get_random_string, remove_container, wait_until
 
 
 class PostgresServer:
@@ -38,15 +36,27 @@ class PostgresServer:
         """
         return self.postgres_pass
 
-    def _wait_for_startup(self) -> None:
+    def _is_ready(self) -> bool:
         """
-        Wait for the postgres server to start
+        Return True once `pg_isready` reports the server accepts connections.
         """
-        for i in range(1, 120):
-            logs = self.instance.logs().decode()
-            if "ready for start up" in logs:
-                return
-            time.sleep(i)
+        try:
+            result = self.instance.exec_run(
+                ['pg_isready', '-U', 'postgres', '-d', self._db_name])
+        except docker.errors.APIError:
+            return False
+        return result.exit_code == 0
+
+    def _wait_for_startup(self, timeout: float = 120.0) -> None:
+        """
+        Wait for the postgres server to accept connections.
+        Raises TimeoutError if the server is not ready in time.
+        """
+        wait_until(
+            self._is_ready,
+            timeout=timeout,
+            interval=1.0,
+            description=f"postgres {self.name} to accept connections")
 
     def start(self) -> None:
         """

--- a/services/smm.py
+++ b/services/smm.py
@@ -4,7 +4,8 @@ See: https://github.com/canterbury-air-patrol/search-management-map
 """
 
 import random
-import time
+import urllib.error
+import urllib.request
 
 import docker
 import docker.errors
@@ -12,7 +13,12 @@ import docker.errors
 from smm_client.connection import SMMConnection
 
 from .postgres import PostgresServer
-from .helpers import get_random_string, remove_container, remove_network
+from .helpers import (
+    get_random_string,
+    remove_container,
+    remove_network,
+    wait_until,
+)
 
 
 class SMMServer:
@@ -63,15 +69,28 @@ class SMMServer:
         if self.external_network is not None:
             self.external_network.connect(self.instance)
 
-    def _wait_for_web_startup(self) -> None:
+    def _is_web_ready(self) -> bool:
         """
-        Wait until the web server starts before continuing
+        Return True when an HTTP GET to the server returns any 2xx/3xx.
         """
-        for i in range(1, 120):
-            logs = self.instance.logs().decode()
-            if f"http://0.0.0.0:{self.internal_port}" in logs:
-                return
-            time.sleep(i)
+        try:
+            with urllib.request.urlopen(
+                    f'http://localhost:{self.port}/',
+                    timeout=2) as resp:
+                return 200 <= resp.status < 400
+        except (urllib.error.URLError, OSError):
+            return False
+
+    def _wait_for_web_startup(self, timeout: float = 120.0) -> None:
+        """
+        Wait until the web server accepts HTTP requests.
+        Raises TimeoutError if the server does not respond in time.
+        """
+        wait_until(
+            self._is_web_ready,
+            timeout=timeout,
+            interval=1.0,
+            description=f"SMM {self.name} web server on port {self.port}")
 
     def start(self) -> None:
         """

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -55,10 +55,17 @@ class WaitUntilTests(unittest.TestCase):
     def test_raises_timeout_when_deadline_passes(self) -> None:
         clock = FakeClock()
         with self._patch_clock(clock):
-            with self.assertRaises(TimeoutError):
-                wait_until(lambda: False, timeout=5, interval=1)
+            with self.assertRaises(TimeoutError) as cm:
+                wait_until(
+                    lambda: False,
+                    timeout=5,
+                    interval=1,
+                    description="waiting for condition")
         # 5 sleeps of 1 second each exhaust the budget
         self.assertEqual(sum(clock.sleeps), 5)
+        message = str(cm.exception)
+        self.assertIn("5s", message)
+        self.assertIn("waiting for condition", message)
 
     def test_final_sleep_clipped_to_remaining_budget(self) -> None:
         clock = FakeClock()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for services.helpers.wait_until.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from services.helpers import wait_until
+
+
+class FakeClock:
+    """
+    Drives monotonic time forward only when sleep() is called, so tests
+    run without touching the real wall clock.
+    """
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+class WaitUntilTests(unittest.TestCase):
+    def _patch_clock(self, clock: FakeClock):
+        return patch.multiple(
+            'services.helpers.time',
+            monotonic=clock.monotonic,
+            sleep=clock.sleep)
+
+    def test_returns_immediately_when_predicate_true(self) -> None:
+        clock = FakeClock()
+        with self._patch_clock(clock):
+            wait_until(lambda: True, timeout=10, interval=1)
+        self.assertEqual(clock.sleeps, [])
+
+    def test_retries_until_predicate_true(self) -> None:
+        clock = FakeClock()
+        attempts = {'n': 0}
+
+        def predicate() -> bool:
+            attempts['n'] += 1
+            return attempts['n'] >= 3
+
+        with self._patch_clock(clock):
+            wait_until(predicate, timeout=10, interval=1)
+
+        self.assertEqual(attempts['n'], 3)
+        self.assertEqual(clock.sleeps, [1, 1])
+
+    def test_raises_timeout_when_deadline_passes(self) -> None:
+        clock = FakeClock()
+        with self._patch_clock(clock):
+            with self.assertRaises(TimeoutError):
+                wait_until(lambda: False, timeout=5, interval=1)
+        # 5 sleeps of 1 second each exhaust the budget
+        self.assertEqual(sum(clock.sleeps), 5)
+
+    def test_final_sleep_clipped_to_remaining_budget(self) -> None:
+        clock = FakeClock()
+        with self._patch_clock(clock):
+            with self.assertRaises(TimeoutError):
+                wait_until(lambda: False, timeout=2.5, interval=1)
+        self.assertEqual(clock.sleeps, [1, 1, 0.5])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Replace log-string scraping plus the unintended ~2h growing-sleep loop with a shared wait_until helper that polls a predicate on a fixed interval and raises TimeoutError once the deadline passes. Postgres now probes via `pg_isready` inside the container; SMM probes via an HTTP GET accepting any 2xx/3xx response.

## Summary by Sourcery

Introduce a shared bounded wait helper and use real readiness probes for Postgres and SMM services.

New Features:
- Add a generic wait_until helper to poll a predicate with a bounded timeout and configurable interval.

Enhancements:
- Switch Postgres readiness detection to use pg_isready inside the container instead of log scraping.
- Switch SMM readiness detection to HTTP-based health probing against the exposed web endpoint instead of log scraping.

Tests:
- Add unit tests for the wait_until helper using a fake monotonic clock to validate retry, timeout, and sleep budgeting behavior.