### PR TITLE
Let Docker assign host ports to eliminate collision risk

### DIFF
--- a/services/smm.py
+++ b/services/smm.py
@@ -3,7 +3,6 @@ Manage Instances of Search Management Map
 See: https://github.com/canterbury-air-patrol/search-management-map
 """
 
-import random
 import urllib.error
 import urllib.request
 
@@ -27,7 +26,7 @@ class SMMServer:
     A Search Management Map Instance
     """
     def __init__(self, name: str, network, docker_client) -> None:
-        self.port = random.randint(20000, 65000)
+        self.port = None
         self.name = name
         self.external_network = network
         self.internal_port = 8080
@@ -62,7 +61,7 @@ class SMMServer:
                 'DJANGO_SUPERUSER_EMAIL=me@example.com',
             ],
             ports={
-                f'{self.internal_port}/tcp': self.port,
+                f'{self.internal_port}/tcp': None,
             },
         )
         self.db_net.connect(self.instance)
@@ -98,6 +97,10 @@ class SMMServer:
         """
         self.postgres.start()
         self.instance.start()
+        self.instance.reload()
+        port_bindings = self.instance.attrs['NetworkSettings']['Ports']
+        self.port = int(
+            port_bindings[f'{self.internal_port}/tcp'][0]['HostPort'])
         self._wait_for_web_startup()
 
     def stop(self) -> None:

--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -1,8 +1,6 @@
 """
 Vehicles
 """
-import random
-
 import docker
 import docker.errors
 
@@ -24,7 +22,6 @@ class Vehicle:
         password,
         lat=-43.5,
         lon=172.5,
-        idx=None
     ) -> None:
         docker_client = docker.from_env()
         self.prefix_name = f'{smm_server.name}_{sanitize_account_name(name)}'
@@ -34,8 +31,6 @@ class Vehicle:
             self.net = docker_client.networks.create(
                 f'ap_{self.prefix_name}-net',
                 driver='bridge')
-        self.ext_port = \
-            31000 + idx if idx is not None else random.randint(30000, 31000)
         self.apm = docker_client.containers.create(
             f'sparlane/ardupilot-sitl:{aircraft_type}-latest',
             detach=True,
@@ -68,7 +63,7 @@ class Vehicle:
                 'BATT_CAPACITY=100000',
             ],
             ports={
-                '5761/tcp': self.ext_port,
+                '5761/tcp': None,
             }
         )
         self.net.connect(self.mavproxy)


### PR DESCRIPTION
Replace random.randint port selection in SMM and Vehicle with OS-assigned ports (host port None), reading the actual bound port from container attrs after start. Drops the idx parameter from Vehicle entirely.

## Summary by Sourcery

Let Docker assign host ports for SMM and vehicle containers to avoid port collisions and propagate the actual bound port into the SMM server state.

Enhancements:
- Replace random host port selection with Docker-assigned host ports for SMM and vehicle containers.
- Remove the vehicle index-based external port configuration in favor of OS-assigned ports.