### PR TITLE
Fail fast on invalid config with typed dataclasses and clear errors

### DIFF
--- a/configloader.py
+++ b/configloader.py
@@ -3,18 +3,40 @@ Parser to load config for mission/participants
 """
 
 import json
+from typing import Any
+
 import yaml
 
+from configmodels import MissionConfig, ParticipantConfig
 
-def load_config(filename) -> object:
+
+def load_config(filename: str) -> dict[str, Any]:
     """
-    Load the config from a yaml or json file
+    Load the config from a yaml or json file.
+    Raises ValueError for unsupported extensions.
     """
-    config = None
     if filename.endswith('.yml') or filename.endswith('.yaml'):
         with open(filename, 'r', encoding='utf-8') as file:
-            config = yaml.safe_load(file)
-    elif filename.endswith('.json'):
+            return yaml.safe_load(file)
+    if filename.endswith('.json'):
         with open(filename, 'r', encoding='utf-8') as file:
-            config = json.load(file)
-    return config
+            return json.load(file)
+    raise ValueError(
+        f"{filename}: unsupported file extension"
+        " (expected .yml, .yaml, or .json)")
+
+
+def load_mission_config(filename: str) -> MissionConfig:
+    """
+    Load and validate a mission config file.
+    """
+    data = load_config(filename)
+    return MissionConfig.from_dict(data, filename)
+
+
+def load_participant_config(filename: str) -> ParticipantConfig:
+    """
+    Load and validate a participant config file.
+    """
+    data = load_config(filename)
+    return ParticipantConfig.from_dict(data, filename)

--- a/configmodels.py
+++ b/configmodels.py
@@ -1,0 +1,141 @@
+"""
+Typed dataclasses for mission and participant config files
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ConfigError(Exception):
+    """Raised when a config file is missing required fields."""
+
+
+def _require(data: dict, key: str, filepath: str, prefix: str) -> Any:
+    if key not in data or data[key] is None:
+        field_path = f"{prefix}.{key}" if prefix else key
+        raise ConfigError(f"{filepath}: {field_path} is required")
+    return data[key]
+
+
+@dataclass
+class BaseLocation:
+    """Latitude/longitude pair for an asset's base."""
+
+    latitude: float
+    longitude: float
+
+    @classmethod
+    def from_dict(cls, data: dict, filepath: str, prefix: str) -> BaseLocation:
+        """Build from a raw dict, raising ConfigError on missing fields."""
+        lat = _require(data, 'latitude', filepath, prefix)
+        lon = _require(data, 'longitude', filepath, prefix)
+        return cls(latitude=float(lat), longitude=float(lon))
+
+
+@dataclass
+class AssetConfig:
+    """Config for a single mission asset."""
+
+    name: str
+    type: str
+    organization: str
+    response_time_mins: int
+    base_location: BaseLocation
+
+    @classmethod
+    def from_dict(cls, data: dict, filepath: str, prefix: str) -> AssetConfig:
+        """Build from a raw dict, raising ConfigError on missing fields."""
+        name = _require(data, 'name', filepath, prefix)
+        type_ = _require(data, 'type', filepath, prefix)
+        org = _require(data, 'organization', filepath, prefix)
+        rtm = _require(data, 'responseTimeMins', filepath, prefix)
+        bl_data = _require(data, 'baseLocation', filepath, prefix)
+        base_location = BaseLocation.from_dict(
+            bl_data, filepath, f"{prefix}.baseLocation")
+        return cls(
+            name=str(name),
+            type=str(type_),
+            organization=str(org),
+            response_time_mins=int(rtm),
+            base_location=base_location,
+        )
+
+
+@dataclass
+class POIConfig:
+    """A point of interest in a mission."""
+
+    name: str
+    location: dict[str, float]
+
+
+@dataclass
+class MissionConfig:
+    """Top-level mission configuration."""
+
+    name: str
+    description: str
+    assets: list[AssetConfig]
+    pois: list[POIConfig] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict, filepath: str) -> MissionConfig:
+        """Build from a raw dict, raising ConfigError on missing fields."""
+        name = _require(data, 'name', filepath, '')
+        description = _require(data, 'description', filepath, '')
+        assets_data = _require(data, 'assets', filepath, '')
+        assets = [
+            AssetConfig.from_dict(a, filepath, f"assets[{i}]")
+            for i, a in enumerate(assets_data)
+        ]
+        pois = []
+        if data.get('POIs'):
+            for poi in data['POIs']:
+                if isinstance(poi, dict) \
+                        and 'name' in poi and 'location' in poi:
+                    pois.append(POIConfig(
+                        name=poi['name'],
+                        location=poi['location'],
+                    ))
+        return cls(
+            name=str(name),
+            description=str(description),
+            assets=assets,
+            pois=pois,
+        )
+
+
+@dataclass
+class MemberConfig:
+    """A single participant team member with login credentials."""
+
+    username: str
+    password: str
+
+    @classmethod
+    def from_dict(cls, data: dict, filepath: str, prefix: str) -> MemberConfig:
+        """Build from a raw dict, raising ConfigError on missing fields."""
+        username = _require(data, 'username', filepath, prefix)
+        password = _require(data, 'password', filepath, prefix)
+        return cls(username=str(username), password=str(password))
+
+
+@dataclass
+class ParticipantConfig:
+    """Top-level participant configuration."""
+
+    name: str
+    members: list[MemberConfig]
+
+    @classmethod
+    def from_dict(cls, data: dict, filepath: str) -> ParticipantConfig:
+        """Build from a raw dict, raising ConfigError on missing fields."""
+        name = _require(data, 'name', filepath, '')
+        members_data = _require(data, 'members', filepath, '')
+        members = [
+            MemberConfig.from_dict(m, filepath, f"members[{i}]")
+            for i, m in enumerate(members_data)
+        ]
+        return cls(name=str(name), members=members)

--- a/instance.py
+++ b/instance.py
@@ -2,7 +2,8 @@
 Classes to run an instance of IMT
 """
 
-from configloader import load_config
+from configloader import load_participant_config
+from configmodels import ParticipantConfig
 from services.smm import SMMServer
 
 
@@ -11,20 +12,10 @@ class Participant:
     State for a participant
     """
     def __init__(self, filename: str) -> None:
-        self.load_config(filename)
+        config: ParticipantConfig = load_participant_config(filename)
+        self.name = config.name
+        self.members = config.members
         self.smm = None
-
-    def load_config(self, filename: str) -> bool:
-        """
-        Load in the participant config
-        """
-        config = load_config(filename)
-        if config is None:
-            return False
-        # These inputs should get checked
-        self.name = config['name']
-        self.members = config['members']
-        return True
 
     def start(self, docker_client) -> None:
         """
@@ -41,8 +32,8 @@ class Participant:
         imt_org = smm_admin.create_organization('IMT')
         for member in self.members:
             user = smm_admin.create_user(
-                member['username'],
-                member['password'])
+                member.username,
+                member.password)
             imt_org.add_member(user)
 
     def stop(self) -> None:

--- a/letsgo.py
+++ b/letsgo.py
@@ -6,10 +6,12 @@ Start an IMT Challenge based on a config file
 import argparse
 import contextlib
 import signal
+import sys
 import time
 
 import docker
 
+from configmodels import ConfigError
 from instance import Participant
 from mission import MissionRunner
 
@@ -67,13 +69,16 @@ if __name__ == "__main__":
 
     _install_signal_handlers()
 
+    try:
+        runner = MissionRunner(args.mission)
+        participant_services = [
+            Participant(participant) for participant in args.participant
+        ]
+    except (ConfigError, ValueError) as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+
     docker_client = docker.from_env()
-
-    runner = MissionRunner(args.mission)
-
-    participant_services = [
-        Participant(participant) for participant in args.participant
-    ]
 
     with contextlib.ExitStack() as cleanup_stack:
         if not args.keep:

--- a/mission.py
+++ b/mission.py
@@ -14,7 +14,8 @@ from smm_client.types import SMMPoint
 
 from services.helpers import get_random_secret, sanitize_account_name
 from services.vehicle import Vehicle
-from configloader import load_config
+from configloader import load_mission_config
+from configmodels import AssetConfig, MissionConfig
 
 if TYPE_CHECKING:
     from services.smm import SMMServer
@@ -70,7 +71,7 @@ class VehicleDocker:
     """
     Docker handler for vehicles
     """
-    def __init__(self, config, smm, username, password):
+    def __init__(self, config: AssetConfig, smm, username, password):
         self.config = config
         self.smm = smm
         self.username = username
@@ -91,15 +92,15 @@ class VehicleDocker:
         """
         Start this vehicle
         """
-        vehicle_type = self._map_vehicle_type(self.config['type'])
+        vehicle_type = self._map_vehicle_type(self.config.type)
         self._vehicle = Vehicle(
-            self.config['name'],
+            self.config.name,
             vehicle_type,
             self.smm,
             self.username,
             self.password,
-            lat=self.config['baseLocation']['latitude'],
-            lon=self.config['baseLocation']['longitude'])
+            lat=self.config.base_location.latitude,
+            lon=self.config.base_location.longitude)
         self._vehicle.start()
 
     def stop(self):
@@ -119,7 +120,7 @@ class ParticipantAsset:
     def __init__(
         self,
         parent,
-        config,
+        config: AssetConfig,
         smm_asset,
         smm_connection,
         smm_username,
@@ -167,8 +168,7 @@ class ParticipantAsset:
         if self.launch_time is not None:
             return False
         now = time.time()
-        return now - self.added_time >= \
-            (int(self.config['responseTimeMins']) * 60)
+        return now - self.added_time >= (self.config.response_time_mins * 60)
 
     def time_tick(self):
         """
@@ -235,26 +235,26 @@ class MissionRunnerParticipant:
 
     def _setup_asset(
             self,
-            asset,
+            asset: AssetConfig,
             smm_admin,
             smm_imt_challenge) -> None:
         """
         Setup the asset in SMM
         """
-        asset_account = self.get_user_account_asset(asset['name'])
+        asset_account = self.get_user_account_asset(asset.name)
         asset_smm_account = smm_admin.create_user(
             asset_account['username'],
             asset_account['password'])
         asset_smm = smm_admin.create_asset(
             asset_smm_account,
-            asset['name'],
-            smm_get_or_create_asset_type(smm_admin, asset['type']))
+            asset.name,
+            smm_get_or_create_asset_type(smm_admin, asset.type))
         smm_asset = self.smm.get_web_connection(
             asset_account['username'],
             asset_account['password'])
         organization = smm_get_or_create_organization(
             smm_imt_challenge,
-            asset['organization'])
+            asset.organization)
         organization.add_member(asset_smm_account, role='A')
         org_asset_user = SMMOrganization(
             smm_asset,
@@ -262,7 +262,7 @@ class MissionRunnerParticipant:
             organization.name)
         org_asset_user.add_asset(asset_smm)
         organization.add_member(asset_smm_account, role='M')
-        self.assets[asset['name']] = ParticipantAsset(
+        self.assets[asset.name] = ParticipantAsset(
             self,
             asset,
             asset_smm,
@@ -274,27 +274,26 @@ class MissionRunnerParticipant:
         """
         Add the known assets into the SMM instance
         """
-        if 'assets' in self.parent.config:
+        if self.parent.config.assets:
             smm_admin = self.smm.get_web_connection()
             smm_imt_challenge = self.smm.get_web_connection(
                 'imt-challenge',
                 self.runner_password)
-            for asset in self.parent.config['assets']:
+            for asset in self.parent.config.assets:
                 self._setup_asset(asset, smm_admin, smm_imt_challenge)
 
-    def _add_poi_to_mission(self, mission: SMMMission, poi: dict) -> bool:
+    def _add_poi_to_mission(self, mission: SMMMission, poi) -> bool:
         """
         Add a POI to a mission
         """
-        location = poi.get('location')
+        location = poi.location
         if not isinstance(location, dict):
             return False
         point = None
         if 'latitude' in location and 'longitude' in location:
             point = SMMPoint(location['latitude'], location['longitude'])
-        name = poi.get('name')
-        if point is not None and name is not None:
-            mission.add_waypoint(point, name)
+        if point is not None:
+            mission.add_waypoint(point, poi.name)
             return True
         return False
 
@@ -312,14 +311,11 @@ class MissionRunnerParticipant:
         """
         smm_imt_challenge = self._get_smm_imt_challenge()
         mission = smm_imt_challenge.create_mission(
-            self.parent.config['name'],
-            self.parent.config['description'])
+            self.parent.config.name,
+            self.parent.config.description)
         self.mission_id = mission.id
-        if 'POIs' in self.parent.config:
-            for poi in self.parent.config['POIs']:
-                if not isinstance(poi, dict):
-                    continue
-                self._add_poi_to_mission(mission, poi)
+        for poi in self.parent.config.pois:
+            self._add_poi_to_mission(mission, poi)
 
         organisations = smm_imt_challenge.get_organizations(all_orgs=True)
         for organisation in organisations:
@@ -335,7 +331,7 @@ class MissionRunnerParticipant:
         """
         Get the specific mission we are monitoring
         """
-        return SMMMission(conn, self.mission_id, self.parent.config['name'])
+        return SMMMission(conn, self.mission_id, self.parent.config.name)
 
     def check_added_organizations(self):
         """
@@ -355,12 +351,11 @@ class MissionRunnerParticipant:
                 if not found:
                     new_orgs.append(org.organization)
             # Might need to add assets in response to this
-            for asset in self.parent.config['assets']:
-                if self.assets[asset['name']].added_time is None:
+            for asset in self.parent.config.assets:
+                if self.assets[asset.name].added_time is None:
                     for org in new_orgs:
-                        if asset['organization'] == org.name:
-                            # Add this asset
-                            self.assets[asset['name']].add_to_mission()
+                        if asset.organization == org.name:
+                            self.assets[asset.name].add_to_mission()
 
     def stop(self) -> None:
         """
@@ -381,8 +376,8 @@ class MissionRunner:
     """
     Runner for a Mission
     """
-    def __init__(self, filename) -> None:
-        self.config = load_config(filename)
+    def __init__(self, filename: str) -> None:
+        self.config: MissionConfig = load_mission_config(filename)
         self.participants = []
 
     def add_participant(self, smm: SMMServer) -> None:


### PR DESCRIPTION
Introduce configmodels.py with MissionConfig, ParticipantConfig, and nested dataclasses. load_config now raises ValueError for unknown extensions; load_mission_config/load_participant_config validate all required fields at load time, raising ConfigError with messages like "mission.yml: assets[0].organization is required". letsgo.py catches these errors before any Docker containers start. All dict access in mission.py and instance.py replaced with typed attribute access.

## Summary by Sourcery

Validate mission and participant configs at load time using typed dataclasses and fail fast with clear errors before starting Docker containers.

New Features:
- Introduce typed dataclasses for mission, asset, POI, participant, and member configuration models.
- Add mission- and participant-specific config loaders that build validated typed configs from YAML/JSON files.

Bug Fixes:
- Reject unsupported config file extensions with a clear ValueError instead of silently accepting them.

Enhancements:
- Replace dictionary-based config access in mission and participant runtime code with typed attribute access for safer, clearer logic.
- Propagate configuration validation errors to the CLI entrypoint so misconfigured missions/participants abort early with user-friendly messages.