### PR TITLE
Start participants in parallel to reduce wall-clock setup time

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -8,12 +8,16 @@ import contextlib
 import signal
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import docker
 
 from configmodels import ConfigError
 from instance import Participant
 from mission import MissionRunner
+from services.helpers import pull_images
+from services.postgres import PostgresServer
+from services.smm import SMMServer
 
 
 def arg_is_positive(value) -> int:
@@ -80,6 +84,9 @@ if __name__ == "__main__":
 
     docker_client = docker.from_env()
 
+    n_workers = max(4, len(participant_services))
+    pull_images(docker_client, [PostgresServer.IMAGE, SMMServer.IMAGE])
+
     with contextlib.ExitStack() as cleanup_stack:
         if not args.keep:
             # ExitStack unwinds in reverse, so register participant cleanup
@@ -89,17 +96,23 @@ if __name__ == "__main__":
                 cleanup_stack.callback(participant.cleanup)
             cleanup_stack.callback(runner.stop)
 
-        # Start all the services
-        for participant in participant_services:
-            participant.start(docker_client)
+        # Start all participant services in parallel
+        with ThreadPoolExecutor(max_workers=n_workers) as ex:
+            futures = [
+                ex.submit(p.start, docker_client) for p in participant_services
+            ]
+            for f in futures:
+                f.result()
 
-        # Add each participant to the runner
+        # Add each participant to the runner (serial — touches shared state)
         for participant in participant_services:
             runner.add_participant(participant.smm)
 
-        # Setup the participants in their server
-        for participant in participant_services:
-            participant.setup()
+        # Setup participant accounts in parallel
+        with ThreadPoolExecutor(max_workers=n_workers) as ex:
+            futures = [ex.submit(p.setup) for p in participant_services]
+            for f in futures:
+                f.result()
 
         runner.create_mission()
 

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -6,6 +6,7 @@ import random
 import secrets
 import string
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
 
 import docker
@@ -76,6 +77,16 @@ def wait_until(
             raise TimeoutError(
                 f"Timed out after {timeout:.0f}s waiting for {description}")
         time.sleep(min(interval, remaining))
+
+
+def pull_images(client, images: list) -> None:
+    """
+    Pull all images in parallel. Blocks until all pulls complete.
+    """
+    with ThreadPoolExecutor(max_workers=len(images)) as ex:
+        futures = [ex.submit(client.images.pull, image) for image in images]
+        for f in futures:
+            f.result()
 
 
 def sanitize_account_name(account: str) -> str:

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -13,14 +13,15 @@ class PostgresServer:
     Run a postgresql server in a docker container
     This server will have the postgis extension
     """
+    IMAGE = 'postgis/postgis:17-3.5'
+
     def __init__(self, name, network, db_name, docker_client) -> None:
         self.postgres_pass = get_random_secret(10)
         self.name = name
         self._db_name = db_name
         self.instance = None
-        docker_client.images.pull('postgis/postgis:17-3.5')
         self.instance = docker_client.containers.create(
-            'postgis/postgis:17-3.5',
+            self.IMAGE,
             detach=True,
             name=name,
             environment=[

--- a/services/smm.py
+++ b/services/smm.py
@@ -5,6 +5,7 @@ See: https://github.com/canterbury-air-patrol/search-management-map
 
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 
 import docker
 import docker.errors
@@ -25,6 +26,8 @@ class SMMServer:
     """
     A Search Management Map Instance
     """
+    IMAGE = 'canterburyairpatrol/search-management-map:latest'
+
     def __init__(self, name: str, network, docker_client) -> None:
         self.port = None
         self.name = name
@@ -33,6 +36,7 @@ class SMMServer:
         self.db_net = None
         self.postgres = None
         self.instance = None
+        self.docker_client = docker_client
         try:
             self.db_net = docker_client.networks.get(f'{name}-net')
         except docker.errors.NotFound:
@@ -45,28 +49,6 @@ class SMMServer:
             'smm',
             docker_client)
         self.admin_password = get_random_secret(10)
-        docker_client.images.pull(
-            'canterburyairpatrol/search-management-map:latest')
-        self.instance = docker_client.containers.create(
-            'canterburyairpatrol/search-management-map:latest',
-            detach=True,
-            name=self.name,
-            environment=[
-                f'DB_HOST={self.postgres.name}',
-                f'DB_PASS={self.postgres.get_password()}',
-                'DB_USER=postgres',
-                'DB_NAME=smm',
-                'DJANGO_SUPERUSER_USERNAME=admin',
-                f'DJANGO_SUPERUSER_PASSWORD={self.admin_password}',
-                'DJANGO_SUPERUSER_EMAIL=me@example.com',
-            ],
-            ports={
-                f'{self.internal_port}/tcp': None,
-            },
-        )
-        self.db_net.connect(self.instance)
-        if self.external_network is not None:
-            self.external_network.connect(self.instance)
 
     def _is_web_ready(self) -> bool:
         """
@@ -93,9 +75,34 @@ class SMMServer:
 
     def start(self) -> None:
         """
-        Start this instance, and the related database server
+        Start this instance, and the related database server.
+        Postgres startup and SMM image pull run concurrently.
         """
-        self.postgres.start()
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            pg_future = ex.submit(self.postgres.start)
+            pull_future = ex.submit(self.docker_client.images.pull, self.IMAGE)
+            pg_future.result()
+            pull_future.result()
+        self.instance = self.docker_client.containers.create(
+            self.IMAGE,
+            detach=True,
+            name=self.name,
+            environment=[
+                f'DB_HOST={self.postgres.name}',
+                f'DB_PASS={self.postgres.get_password()}',
+                'DB_USER=postgres',
+                'DB_NAME=smm',
+                'DJANGO_SUPERUSER_USERNAME=admin',
+                f'DJANGO_SUPERUSER_PASSWORD={self.admin_password}',
+                'DJANGO_SUPERUSER_EMAIL=me@example.com',
+            ],
+            ports={
+                f'{self.internal_port}/tcp': None,
+            },
+        )
+        self.db_net.connect(self.instance)
+        if self.external_network is not None:
+            self.external_network.connect(self.instance)
         self.instance.start()
         self.instance.reload()
         port_bindings = self.instance.attrs['NetworkSettings']['Ports']


### PR DESCRIPTION
Pre-pull all required images once before creating any participant, then run each participant's start() and setup() concurrently via ThreadPoolExecutor. Within SMMServer.start(), postgres startup and the SMM image pull (no-op on warm cache) also run in parallel so a cold first run doesn't serialise the two longest waits. Pool size is max(4, participant_count). Failures in any thread propagate through future.result() and the ExitStack handles cleanup for all participants.

## Summary by Sourcery

Start participant services and their backing SMM/Postgres containers in parallel to reduce overall setup time.

New Features:
- Run participant start and setup operations concurrently using a thread pool in the main runner.
- Introduce a shared helper to pre-pull required Docker images in parallel before participant startup.

Enhancements:
- Make Postgres and SMM Docker image names reusable constants on their respective server classes and centralize image pulling inside their start flows.
- Run Postgres startup and SMM image pull concurrently within SMMServer.start() to avoid serializing long I/O operations.