### PR TITLE
Add full type coverage and mypy strict enforcement

### DIFF
--- a/configloader.py
+++ b/configloader.py
@@ -2,8 +2,10 @@
 Parser to load config for mission/participants
 """
 
+from __future__ import annotations
+
 import json
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -17,10 +19,10 @@ def load_config(filename: str) -> dict[str, Any]:
     """
     if filename.endswith('.yml') or filename.endswith('.yaml'):
         with open(filename, 'r', encoding='utf-8') as file:
-            return yaml.safe_load(file)
+            return cast(dict[str, Any], yaml.safe_load(file))
     if filename.endswith('.json'):
         with open(filename, 'r', encoding='utf-8') as file:
-            return json.load(file)
+            return cast(dict[str, Any], json.load(file))
     raise ValueError(
         f"{filename}: unsupported file extension"
         " (expected .yml, .yaml, or .json)")

--- a/configloader.py
+++ b/configloader.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 
 import yaml
 
-from configmodels import MissionConfig, ParticipantConfig
+from configmodels import ConfigError, MissionConfig, ParticipantConfig
 
 
 def load_config(filename: str) -> dict[str, Any]:
@@ -19,13 +19,17 @@ def load_config(filename: str) -> dict[str, Any]:
     """
     if filename.endswith('.yml') or filename.endswith('.yaml'):
         with open(filename, 'r', encoding='utf-8') as file:
-            return cast(dict[str, Any], yaml.safe_load(file))
-    if filename.endswith('.json'):
+            data = yaml.safe_load(file)
+    elif filename.endswith('.json'):
         with open(filename, 'r', encoding='utf-8') as file:
-            return cast(dict[str, Any], json.load(file))
-    raise ValueError(
-        f"{filename}: unsupported file extension"
-        " (expected .yml, .yaml, or .json)")
+            data = json.load(file)
+    else:
+        raise ValueError(
+            f"{filename}: unsupported file extension"
+            " (expected .yml, .yaml, or .json)")
+    if not isinstance(data, dict):
+        raise ConfigError(f"{filename}: config root must be an object")
+    return cast(dict[str, Any], data)
 
 
 def load_mission_config(filename: str) -> MissionConfig:

--- a/configmodels.py
+++ b/configmodels.py
@@ -12,7 +12,7 @@ class ConfigError(Exception):
     """Raised when a config file is missing required fields."""
 
 
-def _require(data: dict, key: str, filepath: str, prefix: str) -> Any:
+def _require(data: dict[str, Any], key: str, filepath: str, prefix: str) -> Any:
     if key not in data or data[key] is None:
         field_path = f"{prefix}.{key}" if prefix else key
         raise ConfigError(f"{filepath}: {field_path} is required")
@@ -27,7 +27,7 @@ class BaseLocation:
     longitude: float
 
     @classmethod
-    def from_dict(cls, data: dict, filepath: str, prefix: str) -> BaseLocation:
+    def from_dict(cls, data: dict[str, Any], filepath: str, prefix: str) -> BaseLocation:
         """Build from a raw dict, raising ConfigError on missing fields."""
         lat = _require(data, 'latitude', filepath, prefix)
         lon = _require(data, 'longitude', filepath, prefix)
@@ -45,7 +45,7 @@ class AssetConfig:
     base_location: BaseLocation
 
     @classmethod
-    def from_dict(cls, data: dict, filepath: str, prefix: str) -> AssetConfig:
+    def from_dict(cls, data: dict[str, Any], filepath: str, prefix: str) -> AssetConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
         name = _require(data, 'name', filepath, prefix)
         type_ = _require(data, 'type', filepath, prefix)
@@ -81,7 +81,7 @@ class MissionConfig:
     pois: list[POIConfig] = field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: dict, filepath: str) -> MissionConfig:
+    def from_dict(cls, data: dict[str, Any], filepath: str) -> MissionConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
         name = _require(data, 'name', filepath, '')
         description = _require(data, 'description', filepath, '')
@@ -115,7 +115,7 @@ class MemberConfig:
     password: str
 
     @classmethod
-    def from_dict(cls, data: dict, filepath: str, prefix: str) -> MemberConfig:
+    def from_dict(cls, data: dict[str, Any], filepath: str, prefix: str) -> MemberConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
         username = _require(data, 'username', filepath, prefix)
         password = _require(data, 'password', filepath, prefix)
@@ -130,7 +130,7 @@ class ParticipantConfig:
     members: list[MemberConfig]
 
     @classmethod
-    def from_dict(cls, data: dict, filepath: str) -> ParticipantConfig:
+    def from_dict(cls, data: dict[str, Any], filepath: str) -> ParticipantConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
         name = _require(data, 'name', filepath, '')
         members_data = _require(data, 'members', filepath, '')

--- a/configmodels.py
+++ b/configmodels.py
@@ -12,7 +12,11 @@ class ConfigError(Exception):
     """Raised when a config file is missing required fields."""
 
 
-def _require(data: dict[str, Any], key: str, filepath: str, prefix: str) -> Any:
+def _require(
+        data: dict[str, Any],
+        key: str,
+        filepath: str,
+        prefix: str) -> Any:
     if key not in data or data[key] is None:
         field_path = f"{prefix}.{key}" if prefix else key
         raise ConfigError(f"{filepath}: {field_path} is required")
@@ -27,7 +31,11 @@ class BaseLocation:
     longitude: float
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any], filepath: str, prefix: str) -> BaseLocation:
+    def from_dict(
+            cls,
+            data: dict[str, Any],
+            filepath: str,
+            prefix: str) -> BaseLocation:
         """Build from a raw dict, raising ConfigError on missing fields."""
         lat = _require(data, 'latitude', filepath, prefix)
         lon = _require(data, 'longitude', filepath, prefix)
@@ -45,7 +53,11 @@ class AssetConfig:
     base_location: BaseLocation
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any], filepath: str, prefix: str) -> AssetConfig:
+    def from_dict(
+            cls,
+            data: dict[str, Any],
+            filepath: str,
+            prefix: str) -> AssetConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
         name = _require(data, 'name', filepath, prefix)
         type_ = _require(data, 'type', filepath, prefix)
@@ -115,7 +127,11 @@ class MemberConfig:
     password: str
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any], filepath: str, prefix: str) -> MemberConfig:
+    def from_dict(
+            cls,
+            data: dict[str, Any],
+            filepath: str,
+            prefix: str) -> MemberConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
         username = _require(data, 'username', filepath, prefix)
         password = _require(data, 'password', filepath, prefix)
@@ -130,7 +146,10 @@ class ParticipantConfig:
     members: list[MemberConfig]
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any], filepath: str) -> ParticipantConfig:
+    def from_dict(
+            cls,
+            data: dict[str, Any],
+            filepath: str) -> ParticipantConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
         name = _require(data, 'name', filepath, '')
         members_data = _require(data, 'members', filepath, '')

--- a/instance.py
+++ b/instance.py
@@ -2,6 +2,10 @@
 Classes to run an instance of IMT
 """
 
+from __future__ import annotations
+
+import docker
+
 from configloader import load_participant_config
 from configmodels import ParticipantConfig
 from services.smm import SMMServer
@@ -15,9 +19,9 @@ class Participant:
         config: ParticipantConfig = load_participant_config(filename)
         self.name = config.name
         self.members = config.members
-        self.smm = None
+        self.smm: SMMServer | None = None
 
-    def start(self, docker_client) -> None:
+    def start(self, docker_client: docker.DockerClient) -> None:
         """
         Start the services for this participant
         """
@@ -28,6 +32,7 @@ class Participant:
         """
         Setup the participant(s) accounts in this instance
         """
+        assert self.smm is not None
         smm_admin = self.smm.get_web_connection()
         imt_org = smm_admin.create_organization('IMT')
         for member in self.members:

--- a/letsgo.py
+++ b/letsgo.py
@@ -3,11 +3,14 @@
 Start an IMT Challenge based on a config file
 """
 
+from __future__ import annotations
+
 import argparse
 import contextlib
 import signal
 import sys
 import time
+import types
 from concurrent.futures import ThreadPoolExecutor
 
 import docker
@@ -20,7 +23,7 @@ from services.postgres import PostgresServer
 from services.smm import SMMServer
 
 
-def arg_is_positive(value) -> int:
+def arg_is_positive(value: str) -> int:
     """
     Make sure the argument is positive
     """
@@ -35,7 +38,7 @@ def arg_is_positive(value) -> int:
 
 
 def _install_signal_handlers() -> None:
-    def _handle(signum, _frame):
+    def _handle(signum: int, _frame: types.FrameType | None) -> None:
         raise KeyboardInterrupt(f"Received signal {signum}")
     signal.signal(signal.SIGINT, _handle)
     signal.signal(signal.SIGTERM, _handle)
@@ -106,6 +109,7 @@ if __name__ == "__main__":
 
         # Add each participant to the runner (serial — touches shared state)
         for participant in participant_services:
+            assert participant.smm is not None
             runner.add_participant(participant.smm)
 
         # Setup participant accounts in parallel
@@ -117,6 +121,7 @@ if __name__ == "__main__":
         runner.create_mission()
 
         for participant in participant_services:
+            assert participant.smm is not None
             print(
                 f"{participant.name}: "
                 f"http://localhost:{participant.smm.port}")

--- a/mission.py
+++ b/mission.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import time
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from smm_client.missions import SMMMission
 from smm_client.organizations import SMMOrganization
@@ -15,12 +15,12 @@ from smm_client.types import SMMPoint
 from services.helpers import get_random_secret, sanitize_account_name
 from services.vehicle import Vehicle
 from configloader import load_mission_config
-from configmodels import AssetConfig, MissionConfig
+from configmodels import AssetConfig, MissionConfig, POIConfig
 
 if TYPE_CHECKING:
     from services.smm import SMMServer
     from smm_client.connection import SMMConnection
-    from smm_client.assets import SMMAssetType
+    from smm_client.assets import SMMAsset, SMMAssetType
     from smm_client.missions import SMMMissionOrganization
 
 MAS_AWAITING_CREW = "Awaiting Crew"
@@ -71,12 +71,12 @@ class VehicleDocker:
     """
     Docker handler for vehicles
     """
-    def __init__(self, config: AssetConfig, smm, username, password):
+    def __init__(self, config: AssetConfig, smm: SMMServer, username: str, password: str) -> None:
         self.config = config
         self.smm = smm
         self.username = username
         self.password = password
-        self._vehicle = None
+        self._vehicle: Vehicle | None = None
 
     def _map_vehicle_type(self, type_name: str) -> str:
         """
@@ -88,7 +88,7 @@ class VehicleDocker:
             return "Plane"
         return "Copter"
 
-    def start(self):
+    def start(self) -> None:
         """
         Start this vehicle
         """
@@ -103,7 +103,7 @@ class VehicleDocker:
             lon=self.config.base_location.longitude)
         self._vehicle.start()
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Stop this vehicle
         """
@@ -119,12 +119,12 @@ class ParticipantAsset:
     """
     def __init__(
         self,
-        parent,
+        parent: MissionRunnerParticipant,
         config: AssetConfig,
-        smm_asset,
-        smm_connection,
-        smm_username,
-        smm_password
+        smm_asset: SMMAsset,
+        smm_connection: SMMConnection,
+        smm_username: str,
+        smm_password: str,
     ) -> None:
         # pylint: disable=R0913,R0917
         self.parent = parent
@@ -133,8 +133,8 @@ class ParticipantAsset:
         self.smm_connection = smm_connection
         self.smm_username = smm_username
         self.smm_password = smm_password
-        self.added_time = None
-        self.launch_time = None
+        self.added_time: float | None = None
+        self.launch_time: float | None = None
         self.vehicle_manager = VehicleDocker(
             self.config,
             self.parent.smm,
@@ -170,7 +170,7 @@ class ParticipantAsset:
         now = time.time()
         return now - self.added_time >= (self.config.response_time_mins * 60)
 
-    def time_tick(self):
+    def time_tick(self) -> None:
         """
         Check if anything needs doing
         """
@@ -197,14 +197,14 @@ class MissionRunnerParticipant:
         self.parent = parent
         self.smm = smm
         self.runner_password = get_random_secret(12)
-        self.mission_id = None
-        self.mission_asset_statuses = {}
+        self.mission_id: int | None = None
+        self.mission_asset_statuses: dict[str, Any] = {}
         self.assets: dict[str, ParticipantAsset] = {}
-        self.asset_accounts = {}
-        self.organization_admins = {}
+        self.asset_accounts: dict[str, dict[str, str]] = {}
+        self.organization_admins: dict[str, Any] = {}
         self.mission_org_list: list[SMMMissionOrganization] = []
 
-    def get_user_account_asset(self, asset: str) -> object:
+    def get_user_account_asset(self, asset: str) -> dict[str, str]:
         """
         Get the user account for a specific asset
         """
@@ -222,7 +222,7 @@ class MissionRunnerParticipant:
         smm_admin = self.smm.get_web_connection()
         smm_admin.create_user('imt-challenge', self.runner_password)
 
-    def setup_mission_asset_statuses(self):
+    def setup_mission_asset_statuses(self) -> None:
         """
         Create the mission asset statuses in SMM
         """
@@ -236,8 +236,8 @@ class MissionRunnerParticipant:
     def _setup_asset(
             self,
             asset: AssetConfig,
-            smm_admin,
-            smm_imt_challenge) -> None:
+            smm_admin: SMMConnection,
+            smm_imt_challenge: SMMConnection) -> None:
         """
         Setup the asset in SMM
         """
@@ -282,7 +282,7 @@ class MissionRunnerParticipant:
             for asset in self.parent.config.assets:
                 self._setup_asset(asset, smm_admin, smm_imt_challenge)
 
-    def _add_poi_to_mission(self, mission: SMMMission, poi) -> bool:
+    def _add_poi_to_mission(self, mission: SMMMission, poi: POIConfig) -> bool:
         """
         Add a POI to a mission
         """
@@ -297,7 +297,7 @@ class MissionRunnerParticipant:
             return True
         return False
 
-    def _get_smm_imt_challenge(self):
+    def _get_smm_imt_challenge(self) -> SMMConnection:
         """
         Get the SMMConnection for the imt challenge runner account
         """
@@ -333,7 +333,7 @@ class MissionRunnerParticipant:
         """
         return SMMMission(conn, self.mission_id, self.parent.config.name)
 
-    def check_added_organizations(self):
+    def check_added_organizations(self) -> None:
         """
         Check if any new organizations have been added to the mission
         """
@@ -378,7 +378,7 @@ class MissionRunner:
     """
     def __init__(self, filename: str) -> None:
         self.config: MissionConfig = load_mission_config(filename)
-        self.participants = []
+        self.participants: list[MissionRunnerParticipant] = []
 
     def add_participant(self, smm: SMMServer) -> None:
         """

--- a/mission.py
+++ b/mission.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import time
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from smm_client.missions import SMMMission
 from smm_client.organizations import SMMOrganization
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
     from smm_client.connection import SMMConnection
     from smm_client.assets import SMMAsset, SMMAssetType
     from smm_client.missions import SMMMissionOrganization
+
+
+class UserAccountAsset(TypedDict):
+    """Credentials for one generated asset account."""
+
+    username: str
+    password: str
+
 
 MAS_AWAITING_CREW = "Awaiting Crew"
 MAS_AWAITING_TASKING = "Awaiting Tasking"
@@ -71,7 +79,13 @@ class VehicleDocker:
     """
     Docker handler for vehicles
     """
-    def __init__(self, config: AssetConfig, smm: SMMServer, username: str, password: str) -> None:
+    def __init__(
+        self,
+        config: AssetConfig,
+        smm: SMMServer,
+        username: str,
+        password: str,
+    ) -> None:
         self.config = config
         self.smm = smm
         self.username = username
@@ -200,11 +214,11 @@ class MissionRunnerParticipant:
         self.mission_id: int | None = None
         self.mission_asset_statuses: dict[str, Any] = {}
         self.assets: dict[str, ParticipantAsset] = {}
-        self.asset_accounts: dict[str, dict[str, str]] = {}
+        self.asset_accounts: dict[str, UserAccountAsset] = {}
         self.organization_admins: dict[str, Any] = {}
         self.mission_org_list: list[SMMMissionOrganization] = []
 
-    def get_user_account_asset(self, asset: str) -> dict[str, str]:
+    def get_user_account_asset(self, asset: str) -> UserAccountAsset:
         """
         Get the user account for a specific asset
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.mypy]
+strict = true
+ignore_missing_imports = true

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import secrets
 import string
 import time
+import random
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
 
@@ -18,7 +19,8 @@ import docker.models.networks
 _SECRET_ALPHABET = string.ascii_letters + string.digits + "-_"
 
 
-def remove_container(container: docker.models.containers.Container | None) -> None:
+def remove_container(
+        container: docker.models.containers.Container | None) -> None:
     """
     Force-remove a docker container, tolerating a container that was
     never started or has already been removed.

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -2,7 +2,8 @@
 String helpers
 """
 
-import random
+from __future__ import annotations
+
 import secrets
 import string
 import time
@@ -11,11 +12,13 @@ from typing import Callable
 
 import docker
 import docker.errors
+import docker.models.containers
+import docker.models.networks
 
 _SECRET_ALPHABET = string.ascii_letters + string.digits + "-_"
 
 
-def remove_container(container) -> None:
+def remove_container(container: docker.models.containers.Container | None) -> None:
     """
     Force-remove a docker container, tolerating a container that was
     never started or has already been removed.
@@ -28,7 +31,7 @@ def remove_container(container) -> None:
         pass
 
 
-def remove_network(network) -> None:
+def remove_network(network: docker.models.networks.Network | None) -> None:
     """
     Remove a docker network, tolerating networks that have already been
     removed or still have endpoints attached.
@@ -43,7 +46,7 @@ def remove_network(network) -> None:
         print(f"Skipping removal of network {network.name}: {exc}")
 
 
-def get_random_string(length) -> str:
+def get_random_string(length: int) -> str:
     """
     Get a random string of ascii chars (non-secret, e.g. account names).
     """
@@ -79,7 +82,7 @@ def wait_until(
         time.sleep(min(interval, remaining))
 
 
-def pull_images(client, images: list) -> None:
+def pull_images(client: docker.DockerClient, images: list[str]) -> None:
     """
     Pull all images in parallel. Blocks until all pulls complete.
     """

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -19,7 +19,12 @@ class PostgresServer:
     """
     IMAGE = 'postgis/postgis:17-3.5'
 
-    def __init__(self, name: str, network: docker.models.networks.Network, db_name: str, docker_client: docker.DockerClient) -> None:
+    def __init__(
+            self,
+            name: str,
+            network: docker.models.networks.Network,
+            db_name: str,
+            docker_client: docker.DockerClient) -> None:
         self.postgres_pass = get_random_secret(10)
         self.name = name
         self._db_name = db_name

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -2,8 +2,12 @@
 Postgres server
 """
 
+from __future__ import annotations
+
 import docker
 import docker.errors
+import docker.models.containers
+import docker.models.networks
 
 from .helpers import get_random_secret, remove_container, wait_until
 
@@ -15,11 +19,11 @@ class PostgresServer:
     """
     IMAGE = 'postgis/postgis:17-3.5'
 
-    def __init__(self, name, network, db_name, docker_client) -> None:
+    def __init__(self, name: str, network: docker.models.networks.Network, db_name: str, docker_client: docker.DockerClient) -> None:
         self.postgres_pass = get_random_secret(10)
         self.name = name
         self._db_name = db_name
-        self.instance = None
+        self.instance: docker.models.containers.Container | None
         self.instance = docker_client.containers.create(
             self.IMAGE,
             detach=True,
@@ -41,12 +45,14 @@ class PostgresServer:
         """
         Return True once `pg_isready` reports the server accepts connections.
         """
+        if self.instance is None:
+            return False
         try:
             result = self.instance.exec_run(
                 ['pg_isready', '-U', 'postgres', '-d', self._db_name])
         except docker.errors.APIError:
             return False
-        return result.exit_code == 0
+        return bool(result.exit_code == 0)
 
     def _wait_for_startup(self, timeout: float = 120.0) -> None:
         """
@@ -63,6 +69,7 @@ class PostgresServer:
         """
         Start this instance
         """
+        assert self.instance is not None
         self.instance.start()
         self._wait_for_startup()
 

--- a/services/smm.py
+++ b/services/smm.py
@@ -3,12 +3,16 @@ Manage Instances of Search Management Map
 See: https://github.com/canterbury-air-patrol/search-management-map
 """
 
+from __future__ import annotations
+
 import os
 import urllib.error
 import urllib.request
 
 import docker
 import docker.errors
+import docker.models.containers
+import docker.models.networks
 
 from smm_client.connection import SMMConnection
 
@@ -33,16 +37,16 @@ class SMMServer:
     def __init__(
             self,
             name: str,
-            network,
-            docker_client,
+            network: docker.models.networks.Network | None,
+            docker_client: docker.DockerClient,
             admin_email: str | None = None) -> None:
-        self.port = None
+        self.port: int | None = None
         self.name = name
         self.external_network = network
         self.internal_port = 8080
-        self.db_net = None
-        self.postgres = None
-        self.instance = None
+        self.db_net: docker.models.networks.Network | None = None
+        self.postgres: PostgresServer | None = None
+        self.instance: docker.models.containers.Container | None = None
         self.docker_client = docker_client
         self.admin_email = (
             admin_email
@@ -70,7 +74,7 @@ class SMMServer:
             with urllib.request.urlopen(
                     f'http://localhost:{self.port}/',
                     timeout=2) as resp:
-                return 200 <= resp.status < 400
+                return bool(200 <= resp.status < 400)
         except (urllib.error.URLError, OSError):
             return False
 
@@ -90,6 +94,8 @@ class SMMServer:
         Start this instance, and the related database server.
         Images are pre-pulled by the caller; only postgres startup runs here.
         """
+        assert self.postgres is not None
+        assert self.db_net is not None
         self.postgres.start()
         self.instance = self.docker_client.containers.create(
             self.IMAGE,
@@ -145,8 +151,8 @@ class SMMServer:
 
     def get_web_connection(
             self,
-            username='admin',
-            password=None) -> SMMConnection:
+            username: str = 'admin',
+            password: str | None = None) -> SMMConnection:
         """
         Return an SMMConnection object connected to this server
         """

--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -42,7 +42,7 @@ class Vehicle:
                 f'ap_{self.prefix_name}-net',
                 driver='bridge')
         self.apm = docker_client.containers.create(
-            f'sparlane/ardupilot-sitl:{aircraft_type}-master',
+            f'sparlane/ardupilot-sitl:{aircraft_type}-latest',
             detach=True,
             name=f'{self.prefix_name}_sitl',
             environment=[

--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -1,11 +1,20 @@
 """
 Vehicles
 """
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import docker
 import docker.errors
+import docker.models.networks
 
 from services.helpers import (
     remove_container, remove_network, sanitize_account_name)
+
+if TYPE_CHECKING:
+    from services.smm import SMMServer
 
 
 class Vehicle:
@@ -15,16 +24,17 @@ class Vehicle:
     # pylint: disable=R0913,R0917
     def __init__(
         self,
-        name,
-        aircraft_type,
-        smm_server,
-        username,
-        password,
-        lat=-43.5,
-        lon=172.5,
+        name: str,
+        aircraft_type: str,
+        smm_server: SMMServer,
+        username: str,
+        password: str,
+        lat: float = -43.5,
+        lon: float = 172.5,
     ) -> None:
         docker_client = docker.from_env()
         self.prefix_name = f'{smm_server.name}_{sanitize_account_name(name)}'
+        self.net: docker.models.networks.Network
         try:
             self.net = docker_client.networks.get(f'ap_{self.prefix_name}-net')
         except docker.errors.NotFound:
@@ -32,7 +42,7 @@ class Vehicle:
                 f'ap_{self.prefix_name}-net',
                 driver='bridge')
         self.apm = docker_client.containers.create(
-            f'sparlane/ardupilot-sitl:{aircraft_type}-latest',
+            f'sparlane/ardupilot-sitl:{aircraft_type}-master',
             detach=True,
             name=f'{self.prefix_name}_sitl',
             environment=[
@@ -81,9 +91,10 @@ class Vehicle:
             detach=True,
             name=f'{self.prefix_name}_smm_mavlink')
         self.net.connect(self.smm_mavlink)
+        assert smm_server.db_net is not None
         smm_server.db_net.connect(self.smm_mavlink)
 
-    def start(self):
+    def start(self) -> None:
         """
         Start the vehicle
         """
@@ -91,7 +102,7 @@ class Vehicle:
         self.mavproxy.start()
         self.smm_mavlink.start()
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Stop and tear down the vehicle containers and their private network.
         Idempotent and tolerant of containers that never started or are

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,8 @@ Unit tests for services.helpers.wait_until.
 """
 
 import unittest
+from contextlib import AbstractContextManager
+from typing import Any
 from unittest.mock import patch
 
 from services.helpers import get_random_secret, wait_until
@@ -40,7 +42,7 @@ class GetRandomSecretTests(unittest.TestCase):
 
 
 class WaitUntilTests(unittest.TestCase):
-    def _patch_clock(self, clock: FakeClock):
+    def _patch_clock(self, clock: FakeClock) -> AbstractContextManager[Any]:
         return patch.multiple(
             'services.helpers.time',
             monotonic=clock.monotonic,


### PR DESCRIPTION
Every public function now has accurate parameter and return types; `mypy --strict` passes clean across all project modules. Configures mypy in pyproject.toml with strict=true and ignore_missing_imports=true for third-party deps.

## Summary by Sourcery

Enforce strict static typing across the project and configure mypy accordingly.

Enhancements:
- Add precise type annotations for public interfaces, internal attributes, and helper utilities to satisfy mypy strict mode.
- Tighten Docker- and SMM-related classes with explicit types, assertions, and safe handling of optional resources.
- Refine config loading and model construction functions to use typed dictionaries and casts for structured config data.

Build:
- Add a mypy configuration in pyproject.toml to enable strict type checking while tolerating missing third-party type stubs.