### PR TITLE
Replace print() with logging and add lifecycle observability

### DIFF
--- a/instance.py
+++ b/instance.py
@@ -46,7 +46,10 @@ class Participant:
                 member.username,
                 member.password)
             imt_org.add_member(user)
-            log.debug("Created user %s for participant %s", member.username, self.name)
+            log.debug(
+                "Created user %s for participant %s",
+                member.username,
+                self.name)
 
     def stop(self) -> None:
         """

--- a/instance.py
+++ b/instance.py
@@ -4,11 +4,15 @@ Classes to run an instance of IMT
 
 from __future__ import annotations
 
+import logging
+
 import docker
 
 from configloader import load_participant_config
 from configmodels import ParticipantConfig
 from services.smm import SMMServer
+
+log = logging.getLogger(__name__)
 
 
 class Participant:
@@ -25,6 +29,7 @@ class Participant:
         """
         Start the services for this participant
         """
+        log.info("Starting participant %s", self.name)
         self.smm = SMMServer(f'{self.name}-smm', None, docker_client)
         self.smm.start()
 
@@ -33,6 +38,7 @@ class Participant:
         Setup the participant(s) accounts in this instance
         """
         assert self.smm is not None
+        log.info("Setting up accounts for participant %s", self.name)
         smm_admin = self.smm.get_web_connection()
         imt_org = smm_admin.create_organization('IMT')
         for member in self.members:
@@ -40,6 +46,7 @@ class Participant:
                 member.username,
                 member.password)
             imt_org.add_member(user)
+            log.debug("Created user %s for participant %s", member.username, self.name)
 
     def stop(self) -> None:
         """
@@ -53,6 +60,8 @@ class Participant:
         Cleanup the services for this participant.
         Safe to call if start() was never reached or only partially succeeded.
         """
+        log.debug("Cleaning up participant %s", self.name)
         if self.smm is not None:
             self.smm.cleanup()
             self.smm = None
+        log.debug("Participant %s cleanup complete", self.name)

--- a/letsgo.py
+++ b/letsgo.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import logging
 import signal
 import sys
 import time
@@ -19,8 +20,11 @@ from configmodels import ConfigError
 from instance import Participant
 from mission import MissionRunner
 from services.helpers import pull_images
+from services.log import configure_logging
 from services.postgres import PostgresServer
 from services.smm import SMMServer
+
+log = logging.getLogger(__name__)
 
 
 def arg_is_positive(value: str) -> int:
@@ -71,8 +75,17 @@ if __name__ == "__main__":
         '--keep',
         action='store_true',
         help='Skip teardown on exit so the operator can inspect state')
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Enable DEBUG logging')
+    parser.add_argument(
+        '-q', '--quiet',
+        action='store_true',
+        help='Suppress INFO logging (WARNING and above only)')
 
     args = parser.parse_args()
+    configure_logging(verbose=args.verbose, quiet=args.quiet)
 
     _install_signal_handlers()
 
@@ -82,7 +95,7 @@ if __name__ == "__main__":
             Participant(participant) for participant in args.participant
         ]
     except (ConfigError, ValueError) as exc:
-        print(exc, file=sys.stderr)
+        log.error("%s", exc)
         sys.exit(1)
 
     docker_client = docker.from_env()
@@ -122,11 +135,9 @@ if __name__ == "__main__":
 
         for participant in participant_services:
             assert participant.smm is not None
-            print(
-                f"{participant.name}: "
-                f"http://localhost:{participant.smm.port}")
+            log.info("%s: http://localhost:%s", participant.name, participant.smm.port)
 
-        print("Ready. Lets go")
+        log.info("Ready. Lets go")
 
         # Run the IMT Challenge
         start_time = time.time()

--- a/letsgo.py
+++ b/letsgo.py
@@ -75,11 +75,12 @@ if __name__ == "__main__":
         '--keep',
         action='store_true',
         help='Skip teardown on exit so the operator can inspect state')
-    parser.add_argument(
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
         '-v', '--verbose',
         action='store_true',
         help='Enable DEBUG logging')
-    parser.add_argument(
+    verbosity.add_argument(
         '-q', '--quiet',
         action='store_true',
         help='Suppress INFO logging (WARNING and above only)')

--- a/letsgo.py
+++ b/letsgo.py
@@ -135,7 +135,10 @@ if __name__ == "__main__":
 
         for participant in participant_services:
             assert participant.smm is not None
-            log.info("%s: http://localhost:%s", participant.name, participant.smm.port)
+            log.info(
+                "%s: http://localhost:%s",
+                participant.name,
+                participant.smm.port)
 
         log.info("Ready. Lets go")
 

--- a/mission.py
+++ b/mission.py
@@ -4,9 +4,12 @@ Mission Config and Control
 
 from __future__ import annotations
 
+import logging
 import time
 
 from typing import TYPE_CHECKING, Any, TypedDict
+
+log = logging.getLogger(__name__)
 
 from smm_client.missions import SMMMission
 from smm_client.organizations import SMMOrganization
@@ -159,6 +162,7 @@ class ParticipantAsset:
         """
         Add this asset to a mission
         """
+        log.info("Adding asset %s to mission", self.config.name)
         mission = SMMMission(self.smm_connection, self.parent.mission_id, "")
         mission.add_asset(self.smm_asset)
         mission.set_asset_status(
@@ -189,6 +193,7 @@ class ParticipantAsset:
         Check if anything needs doing
         """
         if self.should_launch():
+            log.info("Launching asset %s", self.config.name)
             mission = SMMMission(
                 self.smm_connection,
                 self.parent.mission_id,
@@ -398,6 +403,7 @@ class MissionRunner:
         """
         Add a participant
         """
+        log.info("Adding participant %s to mission runner", smm.name)
         participant = MissionRunnerParticipant(self, smm)
         participant.add_imt_login()
         participant.setup_mission_asset_statuses()
@@ -408,6 +414,7 @@ class MissionRunner:
         """
         Create the mission in participants server(s)
         """
+        log.info("Creating mission '%s'", self.config.name)
         for participant in self.participants:
             participant.create_mission()
 
@@ -415,8 +422,10 @@ class MissionRunner:
         """
         Stop this mission
         """
+        log.debug("Stopping mission runner")
         for participant in self.participants:
             participant.stop()
+        log.debug("Mission runner stopped")
 
     def time_tick(self) -> None:
         """

--- a/mission.py
+++ b/mission.py
@@ -9,22 +9,22 @@ import time
 
 from typing import TYPE_CHECKING, Any, TypedDict
 
-log = logging.getLogger(__name__)
-
 from smm_client.missions import SMMMission
 from smm_client.organizations import SMMOrganization
 from smm_client.types import SMMPoint
 
-from services.helpers import get_random_secret, sanitize_account_name
-from services.vehicle import Vehicle
 from configloader import load_mission_config
 from configmodels import AssetConfig, MissionConfig, POIConfig
+from services.helpers import get_random_secret, sanitize_account_name
+from services.vehicle import Vehicle
 
 if TYPE_CHECKING:
     from services.smm import SMMServer
     from smm_client.connection import SMMConnection
     from smm_client.assets import SMMAsset, SMMAssetType
     from smm_client.missions import SMMMissionOrganization
+
+log = logging.getLogger(__name__)
 
 
 class UserAccountAsset(TypedDict):

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -5,10 +5,10 @@ String helpers
 from __future__ import annotations
 
 import logging
+import random
 import secrets
 import string
 import time
-import random
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
 
@@ -51,6 +51,31 @@ def remove_network(network: docker.models.networks.Network | None) -> None:
         log.warning("Skipping removal of network %s: %s", network.name, exc)
 
 
+def log_container_logs_on_timeout(
+        container: docker.models.containers.Container | None,
+        name: str,
+        kind: str,
+        logger: logging.Logger) -> None:
+    """
+    Log recent container output after a readiness timeout.
+    """
+    if container is None:
+        return
+    try:
+        raw = container.logs(tail=200)
+        logger.warning(
+            "%s %s readiness timed out. Container logs:\n%s",
+            kind,
+            name,
+            raw.decode(errors='replace'))
+    except Exception:  # pylint: disable=broad-except
+        logger.debug(
+            "Failed to retrieve logs for %s %s after readiness timeout",
+            kind,
+            name,
+            exc_info=True)
+
+
 def get_random_string(length: int) -> str:
     """
     Get a random string of ascii chars (non-secret, e.g. account names).
@@ -91,6 +116,9 @@ def pull_images(client: docker.DockerClient, images: list[str]) -> None:
     """
     Pull all images in parallel. Blocks until all pulls complete.
     """
+    if not images:
+        log.debug("No images to pull")
+        return
     log.info("Pulling %d image(s): %s", len(images), ", ".join(images))
     with ThreadPoolExecutor(max_workers=len(images)) as ex:
         futures = [ex.submit(client.images.pull, image) for image in images]

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -4,6 +4,7 @@ String helpers
 
 from __future__ import annotations
 
+import logging
 import secrets
 import string
 import time
@@ -15,6 +16,8 @@ import docker
 import docker.errors
 import docker.models.containers
 import docker.models.networks
+
+log = logging.getLogger(__name__)
 
 _SECRET_ALPHABET = string.ascii_letters + string.digits + "-_"
 
@@ -45,7 +48,7 @@ def remove_network(network: docker.models.networks.Network | None) -> None:
     except docker.errors.NotFound:
         pass
     except docker.errors.APIError as exc:
-        print(f"Skipping removal of network {network.name}: {exc}")
+        log.warning("Skipping removal of network %s: %s", network.name, exc)
 
 
 def get_random_string(length: int) -> str:
@@ -88,10 +91,12 @@ def pull_images(client: docker.DockerClient, images: list[str]) -> None:
     """
     Pull all images in parallel. Blocks until all pulls complete.
     """
+    log.info("Pulling %d image(s): %s", len(images), ", ".join(images))
     with ThreadPoolExecutor(max_workers=len(images)) as ex:
         futures = [ex.submit(client.images.pull, image) for image in images]
         for f in futures:
             f.result()
+    log.debug("All images pulled")
 
 
 def sanitize_account_name(account: str) -> str:

--- a/services/log.py
+++ b/services/log.py
@@ -1,0 +1,13 @@
+"""
+Logging configuration
+"""
+
+import logging
+
+
+def configure_logging(verbose: bool = False, quiet: bool = False) -> None:
+    level = logging.WARNING if quiet else (logging.DEBUG if verbose else logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s %(levelname)-7s %(name)s: %(message)s',
+    )

--- a/services/log.py
+++ b/services/log.py
@@ -6,7 +6,11 @@ import logging
 
 
 def configure_logging(verbose: bool = False, quiet: bool = False) -> None:
-    level = logging.WARNING if quiet else (logging.DEBUG if verbose else logging.INFO)
+    """
+    Configure process-wide logging for command-line runs.
+    """
+    level = logging.WARNING if quiet else (
+        logging.DEBUG if verbose else logging.INFO)
     logging.basicConfig(
         level=level,
         format='%(asctime)s %(levelname)-7s %(name)s: %(message)s',

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -1,8 +1,6 @@
 """
 Postgres server
 """
-# pylint: disable=duplicate-code
-
 from __future__ import annotations
 
 import logging
@@ -12,7 +10,12 @@ import docker.errors
 import docker.models.containers
 import docker.models.networks
 
-from .helpers import get_random_secret, remove_container, wait_until
+from .helpers import (
+    get_random_secret,
+    log_container_logs_on_timeout,
+    remove_container,
+    wait_until,
+)
 
 log = logging.getLogger(__name__)
 
@@ -78,14 +81,11 @@ class PostgresServer:
                 interval=1.0,
                 description=f"postgres {self.name} to accept connections")
         except TimeoutError:
-            if self.instance is not None:
-                try:
-                    raw = self.instance.logs(tail=200)
-                    log.warning(
-                        "Postgres %s readiness timed out. Container logs:\n%s",
-                        self.name, raw.decode(errors='replace'))
-                except Exception:  # pylint: disable=broad-except
-                    pass
+            log_container_logs_on_timeout(
+                self.instance,
+                self.name,
+                "Postgres",
+                log)
             raise
         log.debug("Postgres %s is ready", self.name)
 

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -1,6 +1,7 @@
 """
 Postgres server
 """
+# pylint: disable=duplicate-code
 
 from __future__ import annotations
 

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -4,12 +4,16 @@ Postgres server
 
 from __future__ import annotations
 
+import logging
+
 import docker
 import docker.errors
 import docker.models.containers
 import docker.models.networks
 
 from .helpers import get_random_secret, remove_container, wait_until
+
+log = logging.getLogger(__name__)
 
 
 class PostgresServer:
@@ -39,6 +43,7 @@ class PostgresServer:
             ]
         )
         network.connect(self.instance)
+        log.debug("Created postgres container %s", name)
 
     def get_password(self) -> str:
         """
@@ -64,19 +69,34 @@ class PostgresServer:
         Wait for the postgres server to accept connections.
         Raises TimeoutError if the server is not ready in time.
         """
-        wait_until(
-            self._is_ready,
-            timeout=timeout,
-            interval=1.0,
-            description=f"postgres {self.name} to accept connections")
+        log.debug("Waiting for postgres %s to accept connections", self.name)
+        try:
+            wait_until(
+                self._is_ready,
+                timeout=timeout,
+                interval=1.0,
+                description=f"postgres {self.name} to accept connections")
+        except TimeoutError:
+            if self.instance is not None:
+                try:
+                    raw = self.instance.logs(tail=200)
+                    log.warning(
+                        "Postgres %s readiness timed out. Container logs:\n%s",
+                        self.name, raw.decode(errors='replace'))
+                except Exception:  # pylint: disable=broad-except
+                    pass
+            raise
+        log.debug("Postgres %s is ready", self.name)
 
     def start(self) -> None:
         """
         Start this instance
         """
         assert self.instance is not None
+        log.info("Starting postgres %s", self.name)
         self.instance.start()
         self._wait_for_startup()
+        log.info("Postgres %s ready", self.name)
 
     def stop(self) -> None:
         """
@@ -94,5 +114,7 @@ class PostgresServer:
         Cleanup from running this instance.
         Safe to call even if start() was never reached.
         """
+        log.debug("Cleaning up postgres %s", self.name)
         remove_container(self.instance)
         self.instance = None
+        log.debug("Postgres %s cleanup complete", self.name)

--- a/services/smm.py
+++ b/services/smm.py
@@ -2,6 +2,7 @@
 Manage Instances of Search Management Map
 See: https://github.com/canterbury-air-patrol/search-management-map
 """
+# pylint: disable=duplicate-code
 
 from __future__ import annotations
 
@@ -15,17 +16,17 @@ import docker.errors
 import docker.models.containers
 import docker.models.networks
 
-log = logging.getLogger(__name__)
-
 from smm_client.connection import SMMConnection
 
-from .postgres import PostgresServer
 from .helpers import (
     get_random_secret,
     remove_container,
     remove_network,
     wait_until,
 )
+from .postgres import PostgresServer
+
+log = logging.getLogger(__name__)
 
 
 class SMMServer:
@@ -87,7 +88,10 @@ class SMMServer:
         Wait until the web server accepts HTTP requests.
         Raises TimeoutError if the server does not respond in time.
         """
-        log.debug("Waiting for SMM %s web server on port %s", self.name, self.port)
+        log.debug(
+            "Waiting for SMM %s web server on port %s",
+            self.name,
+            self.port)
         try:
             wait_until(
                 self._is_web_ready,

--- a/services/smm.py
+++ b/services/smm.py
@@ -2,8 +2,6 @@
 Manage Instances of Search Management Map
 See: https://github.com/canterbury-air-patrol/search-management-map
 """
-# pylint: disable=duplicate-code
-
 from __future__ import annotations
 
 import logging
@@ -20,6 +18,7 @@ from smm_client.connection import SMMConnection
 
 from .helpers import (
     get_random_secret,
+    log_container_logs_on_timeout,
     remove_container,
     remove_network,
     wait_until,
@@ -99,14 +98,11 @@ class SMMServer:
                 interval=1.0,
                 description=f"SMM {self.name} web server on port {self.port}")
         except TimeoutError:
-            if self.instance is not None:
-                try:
-                    raw = self.instance.logs(tail=200)
-                    log.warning(
-                        "SMM %s readiness timed out. Container logs:\n%s",
-                        self.name, raw.decode(errors='replace'))
-                except Exception:  # pylint: disable=broad-except
-                    pass
+            log_container_logs_on_timeout(
+                self.instance,
+                self.name,
+                "SMM",
+                log)
             raise
         log.debug("SMM %s web server is ready", self.name)
 

--- a/services/smm.py
+++ b/services/smm.py
@@ -5,6 +5,7 @@ See: https://github.com/canterbury-air-patrol/search-management-map
 
 from __future__ import annotations
 
+import logging
 import os
 import urllib.error
 import urllib.request
@@ -13,6 +14,8 @@ import docker
 import docker.errors
 import docker.models.containers
 import docker.models.networks
+
+log = logging.getLogger(__name__)
 
 from smm_client.connection import SMMConnection
 
@@ -59,6 +62,7 @@ class SMMServer:
             self.db_net = docker_client.networks.create(
                 f'{name}-net',
                 driver='bridge')
+            log.debug("Created network %s-net", name)
         self.postgres = PostgresServer(
             f'{name}-db-server',
             self.db_net,
@@ -83,11 +87,24 @@ class SMMServer:
         Wait until the web server accepts HTTP requests.
         Raises TimeoutError if the server does not respond in time.
         """
-        wait_until(
-            self._is_web_ready,
-            timeout=timeout,
-            interval=1.0,
-            description=f"SMM {self.name} web server on port {self.port}")
+        log.debug("Waiting for SMM %s web server on port %s", self.name, self.port)
+        try:
+            wait_until(
+                self._is_web_ready,
+                timeout=timeout,
+                interval=1.0,
+                description=f"SMM {self.name} web server on port {self.port}")
+        except TimeoutError:
+            if self.instance is not None:
+                try:
+                    raw = self.instance.logs(tail=200)
+                    log.warning(
+                        "SMM %s readiness timed out. Container logs:\n%s",
+                        self.name, raw.decode(errors='replace'))
+                except Exception:  # pylint: disable=broad-except
+                    pass
+            raise
+        log.debug("SMM %s web server is ready", self.name)
 
     def start(self) -> None:
         """
@@ -96,6 +113,7 @@ class SMMServer:
         """
         assert self.postgres is not None
         assert self.db_net is not None
+        log.info("Starting SMM %s", self.name)
         self.postgres.start()
         self.instance = self.docker_client.containers.create(
             self.IMAGE,
@@ -117,12 +135,15 @@ class SMMServer:
         self.db_net.connect(self.instance)
         if self.external_network is not None:
             self.external_network.connect(self.instance)
+        log.debug("Created SMM container %s", self.name)
         self.instance.start()
         self.instance.reload()
         port_bindings = self.instance.attrs['NetworkSettings']['Ports']
         self.port = int(
             port_bindings[f'{self.internal_port}/tcp'][0]['HostPort'])
+        log.debug("SMM %s started on port %s", self.name, self.port)
         self._wait_for_web_startup()
+        log.info("SMM %s ready on port %s", self.name, self.port)
 
     def stop(self) -> None:
         """
@@ -141,6 +162,7 @@ class SMMServer:
         Cleanup from running this instance.
         Idempotent and tolerant of partial/failed starts.
         """
+        log.debug("Cleaning up SMM %s", self.name)
         remove_container(self.instance)
         self.instance = None
         if self.postgres is not None:
@@ -148,6 +170,7 @@ class SMMServer:
             self.postgres = None
         remove_network(self.db_net)
         self.db_net = None
+        log.debug("SMM %s cleanup complete", self.name)
 
     def get_web_connection(
             self,

--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -4,6 +4,7 @@ Vehicles
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import docker
@@ -12,6 +13,8 @@ import docker.models.networks
 
 from services.helpers import (
     remove_container, remove_network, sanitize_account_name)
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from services.smm import SMMServer
@@ -93,14 +96,17 @@ class Vehicle:
         self.net.connect(self.smm_mavlink)
         assert smm_server.db_net is not None
         smm_server.db_net.connect(self.smm_mavlink)
+        log.debug("Created vehicle containers for %s", name)
 
     def start(self) -> None:
         """
         Start the vehicle
         """
+        log.info("Starting vehicle %s", self.prefix_name)
         self.apm.start()
         self.mavproxy.start()
         self.smm_mavlink.start()
+        log.debug("Vehicle %s containers started", self.prefix_name)
 
     def stop(self) -> None:
         """


### PR DESCRIPTION
Introduces services/log.py with configure_logging(verbose, quiet) and wires -v/--verbose/-q/--quiet flags into letsgo.py so operators can control output level. Replaces all print() calls with appropriate log levels and adds info/debug lifecycle events throughout (container create/start/ready, asset add/launch, cleanup start/end). On readiness timeout, dumps the last 200 lines of the failing container's logs at WARNING so the operator doesn't need a separate docker logs invocation.

## Summary by Sourcery

Introduce centralized logging configuration and lifecycle observability across services and the CLI.

New Features:
- Add configurable logging setup with verbosity and quiet modes controlled via CLI flags.
- Log recent container output when Postgres or SMM services fail to become ready within the timeout.

Enhancements:
- Replace stdout printing with structured logging across core services and the main runner.
- Add lifecycle logging for container creation, startup, readiness, asset/mission operations, and cleanup to improve operational visibility.