### PR TITLE
Add pytest suite covering helpers, config loading, and mission logic

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -5,3 +5,5 @@ source venv/bin/activate
 pycodestyle *.py */*.py
 
 PYTHONPATH=`pwd` pylint services/ letsgo.py instance.py mission.py
+
+pytest -m "not integration"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [tool.mypy]
 strict = true
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+markers = [
+    "integration: spins up real Docker containers",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest==8.3.5
+pytest-mock==3.14.0

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for configloader.
+"""
+
+import json
+import pathlib
+import textwrap
+
+import pytest
+import yaml
+
+from configloader import load_config, load_mission_config, \
+                         load_participant_config
+from configmodels import ConfigError
+
+
+MINIMAL_MISSION = {
+    "name": "Test Mission",
+    "description": "A test",
+    "assets": [
+        {
+            "name": "Alpha Boat",
+            "type": "Boat",
+            "organization": "TeamAlpha",
+            "responseTimeMins": 5,
+            "baseLocation": {"latitude": -43.5, "longitude": 172.6},
+        }
+    ],
+}
+
+MINIMAL_PARTICIPANT = {
+    "name": "Team Alpha",
+    "members": [{"username": "alice", "password": "secret"}],
+}
+
+
+def _write(tmp_path: pathlib.Path, name: str, data: object) -> str:
+    p = tmp_path / name
+    if name.endswith(".json"):
+        p.write_text(json.dumps(data), encoding="utf-8")
+    else:
+        p.write_text(yaml.dump(data), encoding="utf-8")
+    return str(p)
+
+
+class TestLoadConfig:
+    def test_loads_yaml(self, tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "cfg.yaml", {"key": "value"})
+        assert load_config(path) == {"key": "value"}
+
+    def test_loads_yml(self, tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "cfg.yml", {"a": 1})
+        assert load_config(path) == {"a": 1}
+
+    def test_loads_json(self, tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "cfg.json", {"x": [1, 2]})
+        assert load_config(path) == {"x": [1, 2]}
+
+    def test_unknown_extension_raises(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / "cfg.toml"
+        p.write_text("key = 'value'", encoding="utf-8")
+        with pytest.raises(ValueError, match="unsupported file extension"):
+            load_config(str(p))
+
+    def test_missing_file_raises(self, tmp_path: pathlib.Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_config(str(tmp_path / "nonexistent.yaml"))
+
+
+class TestLoadMissionConfig:
+    def test_valid_mission(self, tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "mission.yaml", MINIMAL_MISSION)
+        cfg = load_mission_config(path)
+        assert cfg.name == "Test Mission"
+        assert len(cfg.assets) == 1
+        assert cfg.assets[0].name == "Alpha Boat"
+        assert cfg.assets[0].response_time_mins == 5
+        assert cfg.assets[0].base_location.latitude == pytest.approx(-43.5)
+
+    def test_mission_with_pois(self, tmp_path: pathlib.Path) -> None:
+        data = dict(MINIMAL_MISSION)
+        data["POIs"] = [
+            {
+                "name": "Clue 1",
+                "location": {"latitude": -43.6, "longitude": 172.7}
+            }
+        ]
+        path = _write(tmp_path, "mission.yaml", data)
+        cfg = load_mission_config(path)
+        assert len(cfg.pois) == 1
+        assert cfg.pois[0].name == "Clue 1"
+
+    def test_missing_name_raises(self, tmp_path: pathlib.Path) -> None:
+        data = {k: v for k, v in MINIMAL_MISSION.items() if k != "name"}
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(ConfigError, match="name is required"):
+            load_mission_config(path)
+
+    def test_missing_assets_raises(self, tmp_path: pathlib.Path) -> None:
+        data = {k: v for k, v in MINIMAL_MISSION.items() if k != "assets"}
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(ConfigError, match="assets is required"):
+            load_mission_config(path)
+
+    def test_missing_asset_base_location_raises(self, tmp_path: pathlib.Path) \
+            -> None:
+        asset = {k: v for k, v in
+                 MINIMAL_MISSION["assets"][0].items()  # type: ignore[index]
+                 if k != "baseLocation"}
+        data = dict(MINIMAL_MISSION, assets=[asset])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(ConfigError, match="baseLocation is required"):
+            load_mission_config(path)
+
+    def test_json_mission(self, tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "mission.json", MINIMAL_MISSION)
+        cfg = load_mission_config(path)
+        assert cfg.name == "Test Mission"
+
+
+class TestLoadParticipantConfig:
+    def test_valid_participant(self, tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "participant.yaml", MINIMAL_PARTICIPANT)
+        cfg = load_participant_config(path)
+        assert cfg.name == "Team Alpha"
+        assert len(cfg.members) == 1
+        assert cfg.members[0].username == "alice"
+
+    def test_missing_members_raises(self, tmp_path: pathlib.Path) -> None:
+        data = {"name": "Team Alpha"}
+        path = _write(tmp_path, "participant.yaml", data)
+        with pytest.raises(ConfigError, match="members is required"):
+            load_participant_config(path)
+
+    def test_member_missing_password_raises(self, tmp_path: pathlib.Path) \
+            -> None:
+        data = {"name": "Team Alpha", "members": [{"username": "alice"}]}
+        path = _write(tmp_path, "participant.yaml", data)
+        with pytest.raises(ConfigError, match="password is required"):
+            load_participant_config(path)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,5 @@
 """
-Unit tests for services.helpers.wait_until.
+Unit tests for services.helpers.
 """
 
 import unittest
@@ -7,7 +7,12 @@ from contextlib import AbstractContextManager
 from typing import Any
 from unittest.mock import patch
 
-from services.helpers import get_random_secret, wait_until
+from services.helpers import (
+    get_random_secret,
+    get_random_string,
+    sanitize_account_name,
+    wait_until,
+)
 
 
 class FakeClock:
@@ -89,6 +94,40 @@ class WaitUntilTests(unittest.TestCase):
             with self.assertRaises(TimeoutError):
                 wait_until(lambda: False, timeout=2.5, interval=1)
         self.assertEqual(clock.sleeps, [1, 1, 0.5])
+
+
+class GetRandomStringTests(unittest.TestCase):
+    def test_length_is_exact(self) -> None:
+        for length in (1, 8, 32):
+            self.assertEqual(len(get_random_string(length)), length)
+
+    def test_only_lowercase_ascii(self) -> None:
+        result = get_random_string(100)
+        self.assertTrue(result.isalpha() and result.islower())
+
+    def test_strings_are_unique(self) -> None:
+        results = [get_random_string(16) for _ in range(10)]
+        self.assertGreater(len(set(results)), 1)
+
+
+class SanitizeAccountNameTests(unittest.TestCase):
+    def test_lowercases_name(self) -> None:
+        self.assertEqual(sanitize_account_name("MyTeam"), "myteam")
+
+    def test_replaces_spaces_with_dots(self) -> None:
+        self.assertEqual(sanitize_account_name("alpha bravo"), "alpha.bravo")
+
+    def test_replaces_slashes_with_dots(self) -> None:
+        self.assertEqual(sanitize_account_name("a/b"), "a.b")
+
+    def test_combined_transforms(self) -> None:
+        self.assertEqual(
+            sanitize_account_name("Alpha Boat/Team"),
+            "alpha.boat.team",
+        )
+
+    def test_already_clean(self) -> None:
+        self.assertEqual(sanitize_account_name("clean"), "clean")
 
 
 if __name__ == '__main__':

--- a/tests/test_mission_logic.py
+++ b/tests/test_mission_logic.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for mission.py
+  — ParticipantAsset and MissionRunnerParticipant logic.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from configmodels import AssetConfig, BaseLocation
+from mission import MissionRunnerParticipant, ParticipantAsset
+
+
+BASE_LOCATION = BaseLocation(latitude=-43.5, longitude=172.6)
+
+
+def _asset_config(
+    name: str = "Alpha Boat",
+    org: str = "TeamAlpha",
+    response_time_mins: int = 5,
+) -> AssetConfig:
+    return AssetConfig(
+        name=name,
+        type="Boat",
+        organization=org,
+        response_time_mins=response_time_mins,
+        base_location=BASE_LOCATION,
+    )
+
+
+def _make_participant_asset(config: AssetConfig) -> ParticipantAsset:
+    parent = MagicMock()
+    return ParticipantAsset(
+        parent=parent,
+        config=config,
+        smm_asset=MagicMock(),
+        smm_connection=MagicMock(),
+        smm_username="user",
+        smm_password="pass",
+    )
+
+
+class TestParticipantAssetShouldLaunch:
+    def test_not_added_returns_false(self) -> None:
+        asset = _make_participant_asset(_asset_config())
+        assert asset.added_time is None
+        assert not asset.should_launch()
+
+    def test_before_response_time_returns_false(self, mocker: MagicMock) \
+            -> None:
+        asset = _make_participant_asset(_asset_config(response_time_mins=5))
+        asset.added_time = 1000.0
+        mocker.patch("mission.time.time", return_value=1000.0 + 4 * 60)
+        assert not asset.should_launch()
+
+    def test_at_response_time_returns_true(self, mocker: MagicMock) -> None:
+        asset = _make_participant_asset(_asset_config(response_time_mins=5))
+        asset.added_time = 1000.0
+        mocker.patch("mission.time.time", return_value=1000.0 + 5 * 60)
+        assert asset.should_launch()
+
+    def test_after_response_time_returns_true(self, mocker: MagicMock) -> None:
+        asset = _make_participant_asset(_asset_config(response_time_mins=2))
+        asset.added_time = 0.0
+        mocker.patch("mission.time.time", return_value=200.0)
+        assert asset.should_launch()
+
+    def test_already_launched_returns_false(self, mocker: MagicMock) -> None:
+        asset = _make_participant_asset(_asset_config(response_time_mins=1))
+        asset.added_time = 0.0
+        asset.launch_time = 60.0
+        mocker.patch("mission.time.time", return_value=999.0)
+        assert not asset.should_launch()
+
+
+def _make_mission_runner_participant(
+    asset_configs: list[AssetConfig],
+) -> MissionRunnerParticipant:
+    mock_runner = MagicMock()
+    mock_runner.config.assets = asset_configs
+    mock_smm = MagicMock()
+    participant = MissionRunnerParticipant(mock_runner, mock_smm)
+    participant.mission_id = 42
+    return participant
+
+
+def _mock_mission_org(org_name: str) -> MagicMock:
+    org = MagicMock()
+    org.name = org_name
+    mission_org = MagicMock()
+    mission_org.organization = org
+    return mission_org
+
+
+class TestCheckAddedOrganizations:
+    def test_matching_org_triggers_add_to_mission(self, mocker: MagicMock) \
+            -> None:
+        config = _asset_config(org="TeamAlpha")
+        participant = _make_mission_runner_participant([config])
+
+        mock_pa = MagicMock(spec=ParticipantAsset)
+        mock_pa.added_time = None
+        participant.assets = {config.name: mock_pa}
+        participant.mission_org_list = []
+
+        mocker.patch.object(participant, "_get_smm_imt_challenge",
+                            return_value=MagicMock())
+        mock_mission = MagicMock()
+        mock_mission.get_organizations.return_value = [
+            _mock_mission_org("TeamAlpha")]
+        mocker.patch.object(participant, "_get_mission",
+                            return_value=mock_mission)
+
+        participant.check_added_organizations()
+
+        mock_pa.add_to_mission.assert_called_once()
+
+    def test_non_matching_org_does_not_trigger(self, mocker: MagicMock) \
+            -> None:
+        config = _asset_config(org="TeamAlpha")
+        participant = _make_mission_runner_participant([config])
+
+        mock_pa = MagicMock(spec=ParticipantAsset)
+        mock_pa.added_time = None
+        participant.assets = {config.name: mock_pa}
+        participant.mission_org_list = []
+
+        mocker.patch.object(participant, "_get_smm_imt_challenge",
+                            return_value=MagicMock())
+        mock_mission = MagicMock()
+        mock_mission.get_organizations.return_value = [
+            _mock_mission_org("TeamBeta")]
+        mocker.patch.object(participant, "_get_mission",
+                            return_value=mock_mission)
+
+        participant.check_added_organizations()
+
+        mock_pa.add_to_mission.assert_not_called()
+
+    def test_already_added_asset_not_re_added(self, mocker: MagicMock) -> None:
+        config = _asset_config(org="TeamAlpha")
+        participant = _make_mission_runner_participant([config])
+
+        mock_pa = MagicMock(spec=ParticipantAsset)
+        mock_pa.added_time = 1000.0  # already added
+        participant.assets = {config.name: mock_pa}
+        participant.mission_org_list = []
+
+        mocker.patch.object(participant, "_get_smm_imt_challenge",
+                            return_value=MagicMock())
+        mock_mission = MagicMock()
+        mock_mission.get_organizations.return_value = [
+            _mock_mission_org("TeamAlpha")]
+        mocker.patch.object(participant, "_get_mission",
+                            return_value=mock_mission)
+
+        participant.check_added_organizations()
+
+        mock_pa.add_to_mission.assert_not_called()
+
+    def test_only_new_orgs_trigger_add(self, mocker: MagicMock) -> None:
+        config = _asset_config(org="TeamBeta")
+        participant = _make_mission_runner_participant([config])
+
+        mock_pa = MagicMock(spec=ParticipantAsset)
+        mock_pa.added_time = None
+        participant.assets = {config.name: mock_pa}
+
+        # Org was already known
+        existing_org_mo = _mock_mission_org("TeamAlpha")
+        participant.mission_org_list = [existing_org_mo]
+
+        mocker.patch.object(participant, "_get_smm_imt_challenge",
+                            return_value=MagicMock())
+        mock_mission = MagicMock()
+        new_org_mo = _mock_mission_org("TeamBeta")
+        mock_mission.get_organizations.return_value = [
+            existing_org_mo, new_org_mo]
+        mocker.patch.object(participant, "_get_mission",
+                            return_value=mock_mission)
+
+        participant.check_added_organizations()
+
+        mock_pa.add_to_mission.assert_called_once()


### PR DESCRIPTION
38 unit tests across three test files; pytest -m "not integration" wired into check-code.sh for fast CI feedback.

## Summary by Sourcery

Add unit test coverage for helper utilities, configuration loading, and mission participant logic, and integrate pytest into the code quality script.

Tests:
- Add tests for random string generation and account name sanitization helper functions.
- Add tests for mission configuration and participant configuration loading, including validation errors across YAML and JSON formats.
- Add tests for ParticipantAsset launch timing and MissionRunnerParticipant organization handling logic.
- Configure pytest defaults via pyproject.toml and wire non-integration test runs into the check-code.sh script for faster feedback.