### PR TITLE
Sanitize Docker resource names

### DIFF
--- a/instance.py
+++ b/instance.py
@@ -10,6 +10,7 @@ import docker
 
 from configloader import load_participant_config
 from configmodels import ParticipantConfig
+from services.helpers import sanitize_docker_name
 from services.smm import SMMServer
 
 log = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ class Participant:
     def __init__(self, filename: str) -> None:
         config: ParticipantConfig = load_participant_config(filename)
         self.name = config.name
+        self.service_name = sanitize_docker_name(config.name)
         self.members = config.members
         self.smm: SMMServer | None = None
 
@@ -30,7 +32,7 @@ class Participant:
         Start the services for this participant
         """
         log.info("Starting participant %s", self.name)
-        self.smm = SMMServer(f'{self.name}-smm', None, docker_client)
+        self.smm = SMMServer(f'{self.service_name}-smm', None, docker_client)
         self.smm.start()
 
     def setup(self) -> None:

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import random
+import re
 import secrets
 import string
 import time
@@ -20,6 +21,7 @@ import docker.models.networks
 log = logging.getLogger(__name__)
 
 _SECRET_ALPHABET = string.ascii_letters + string.digits + "-_"
+_DOCKER_NAME_INVALID_CHARS = re.compile(r"[^a-z0-9_.-]+")
 
 
 def remove_container(
@@ -135,3 +137,15 @@ def sanitize_account_name(account: str) -> str:
     - no slashes
     """
     return account.lower().replace(' ', '.').replace('/', '.')
+
+
+def sanitize_docker_name(name: str) -> str:
+    """
+    Convert a display name into a Docker container/network name fragment.
+    """
+    cleaned = _DOCKER_NAME_INVALID_CHARS.sub("-", name.lower())
+    cleaned = cleaned.strip(".-_")
+    if not cleaned:
+        raise ValueError(
+            f"{name!r} must contain at least one Docker-safe character")
+    return cleaned

--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -12,7 +12,7 @@ import docker.errors
 import docker.models.networks
 
 from services.helpers import (
-    remove_container, remove_network, sanitize_account_name)
+    remove_container, remove_network, sanitize_docker_name)
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +36,9 @@ class Vehicle:
         lon: float = 172.5,
     ) -> None:
         docker_client = docker.from_env()
-        self.prefix_name = f'{smm_server.name}_{sanitize_account_name(name)}'
+        self.prefix_name = (
+            f'{sanitize_docker_name(smm_server.name)}_'
+            f'{sanitize_docker_name(name)}')
         self.net: docker.models.networks.Network
         try:
             self.net = docker_client.networks.get(f'ap_{self.prefix_name}-net')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,6 +11,7 @@ from services.helpers import (
     get_random_secret,
     get_random_string,
     sanitize_account_name,
+    sanitize_docker_name,
     wait_until,
 )
 
@@ -128,6 +129,29 @@ class SanitizeAccountNameTests(unittest.TestCase):
 
     def test_already_clean(self) -> None:
         self.assertEqual(sanitize_account_name("clean"), "clean")
+
+
+class SanitizeDockerNameTests(unittest.TestCase):
+    def test_lowercases_name(self) -> None:
+        self.assertEqual(sanitize_docker_name("TeamAlpha"), "teamalpha")
+
+    def test_replaces_spaces_with_hyphens(self) -> None:
+        self.assertEqual(sanitize_docker_name("Team Alpha"), "team-alpha")
+
+    def test_replaces_invalid_punctuation(self) -> None:
+        self.assertEqual(sanitize_docker_name("Team/Alpha#1"), "team-alpha-1")
+
+    def test_preserves_valid_separators(self) -> None:
+        self.assertEqual(sanitize_docker_name("team.alpha_1"), "team.alpha_1")
+
+    def test_strips_leading_and_trailing_separators(self) -> None:
+        self.assertEqual(
+            sanitize_docker_name("...Team Alpha---"),
+            "team-alpha")
+
+    def test_rejects_empty_result(self) -> None:
+        with self.assertRaises(ValueError):
+            sanitize_docker_name("///")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary by Sourcery

Sanitize participant and server names for use as Docker resource identifiers and update call sites accordingly.

New Features:
- Add helper to sanitize display names into Docker-safe name fragments for containers and networks.

Bug Fixes:
- Ensure Docker resource names are lowercased, use safe separators, and reject names that would result in empty Docker identifiers.

Enhancements:
- Update vehicle and participant service naming to use sanitized Docker-safe names instead of raw display names.

Tests:
- Add unit tests covering Docker name sanitization behavior, including valid transformations and error conditions.