### PR TITLE
Track mission organization polling state

### DIFF
--- a/mission.py
+++ b/mission.py
@@ -340,6 +340,7 @@ class MissionRunnerParticipant:
         for organisation in organisations:
             if organisation.name == 'IMT':
                 mission_org = mission.add_organization(organisation)
+                self.mission_org_list.append(mission_org)
                 # Make it so the IMT members can add other organizations
                 # to the mission
                 # Adding an organization is the trigger event to activate
@@ -375,6 +376,7 @@ class MissionRunnerParticipant:
                     for org in new_orgs:
                         if asset.organization == org.name:
                             self.assets[asset.name].add_to_mission()
+        self.mission_org_list = mission_orgs
 
     def stop(self) -> None:
         """

--- a/tests/test_mission_logic.py
+++ b/tests/test_mission_logic.py
@@ -121,6 +121,35 @@ class TestCheckAddedOrganizations:
 
         mock_pa.add_to_mission.assert_called_once()
 
+    def test_existing_org_is_not_reprocessed(
+            self,
+            mocker: MagicMock) -> None:
+        config = _asset_config(org="TeamAlpha")
+        participant = _make_mission_runner_participant([config])
+
+        mock_pa = MagicMock(spec=ParticipantAsset)
+        mock_pa.added_time = None
+        participant.assets = {config.name: mock_pa}
+        participant.mission_org_list = []
+
+        mocker.patch.object(
+            participant,
+            "_get_smm_imt_challenge",
+            return_value=MagicMock())
+        mock_mission = MagicMock()
+        team_alpha = _mock_mission_org("TeamAlpha")
+        mock_mission.get_organizations.return_value = [team_alpha]
+        mocker.patch.object(
+            participant,
+            "_get_mission",
+            return_value=mock_mission)
+
+        participant.check_added_organizations()
+        participant.check_added_organizations()
+
+        mock_pa.add_to_mission.assert_called_once()
+        assert participant.mission_org_list == [team_alpha]
+
     def test_non_matching_org_does_not_trigger(
             self,
             mocker: MagicMock) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Track mission organizations associated with a mission runner to avoid reprocessing already-added organizations.

Bug Fixes:
- Prevent mission runner assets from being re-added to missions when organizations have already been processed.

Tests:
- Add regression test ensuring existing mission organizations are not reprocessed when checking for added organizations.