### PR TITLE
Clean up partial vehicle creation

### DIFF
--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import docker
 import docker.errors
+import docker.models.containers
 import docker.models.networks
 
 from services.helpers import (
@@ -39,7 +40,40 @@ class Vehicle:
         self.prefix_name = (
             f'{sanitize_docker_name(smm_server.name)}_'
             f'{sanitize_docker_name(name)}')
-        self.net: docker.models.networks.Network
+        self.net: docker.models.networks.Network | None = None
+        self.apm: docker.models.containers.Container | None = None
+        self.mavproxy: docker.models.containers.Container | None = None
+        self.smm_mavlink: docker.models.containers.Container | None = None
+        try:
+            self._create(
+                docker_client,
+                name,
+                aircraft_type,
+                smm_server,
+                username,
+                password,
+                lat,
+                lon)
+        except Exception:  # pylint: disable=broad-exception-caught
+            self.stop()
+            raise
+        log.debug("Created vehicle containers for %s", name)
+
+    # pylint: disable=R0913,R0917
+    def _create(
+        self,
+        docker_client: docker.DockerClient,
+        name: str,
+        aircraft_type: str,
+        smm_server: SMMServer,
+        username: str,
+        password: str,
+        lat: float,
+        lon: float,
+    ) -> None:
+        """
+        Create Docker resources for this vehicle.
+        """
         try:
             self.net = docker_client.networks.get(f'ap_{self.prefix_name}-net')
         except docker.errors.NotFound:
@@ -98,13 +132,15 @@ class Vehicle:
         self.net.connect(self.smm_mavlink)
         assert smm_server.db_net is not None
         smm_server.db_net.connect(self.smm_mavlink)
-        log.debug("Created vehicle containers for %s", name)
 
     def start(self) -> None:
         """
         Start the vehicle
         """
         log.info("Starting vehicle %s", self.prefix_name)
+        assert self.apm is not None
+        assert self.mavproxy is not None
+        assert self.smm_mavlink is not None
         self.apm.start()
         self.mavproxy.start()
         self.smm_mavlink.start()

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -1,0 +1,42 @@
+"""
+Unit tests for vehicle Docker resource handling.
+"""
+
+from unittest.mock import MagicMock
+
+import docker
+import pytest
+
+from services.vehicle import Vehicle
+
+
+def _smm_server() -> MagicMock:
+    smm_server = MagicMock()
+    smm_server.name = "team-alpha-smm"
+    smm_server.internal_port = 8080
+    smm_server.db_net = MagicMock()
+    return smm_server
+
+
+def test_vehicle_constructor_cleans_up_partial_create(
+        mocker: MagicMock) -> None:
+    docker_client = MagicMock()
+    net = MagicMock()
+    apm = MagicMock()
+    mavproxy = MagicMock()
+
+    docker_client.networks.get.side_effect = docker.errors.NotFound("missing")
+    docker_client.networks.create.return_value = net
+    docker_client.containers.create.side_effect = [apm, mavproxy]
+    docker_client.images.pull.side_effect = docker.errors.APIError(
+        "pull failed")
+    mocker.patch(
+        "services.vehicle.docker.from_env",
+        return_value=docker_client)
+
+    with pytest.raises(docker.errors.APIError):
+        Vehicle("Alpha Boat", "Rover", _smm_server(), "user", "pass")
+
+    apm.remove.assert_called_once_with(force=True)
+    mavproxy.remove.assert_called_once_with(force=True)
+    net.remove.assert_called_once_with()


### PR DESCRIPTION
## Summary by Sourcery

Ensure vehicle Docker resources are fully created or cleaned up on constructor failure and add coverage around partial creation cleanup.

Bug Fixes:
- Prevent partially created vehicle Docker resources from being left behind when the constructor fails.

Tests:
- Add unit test verifying that partially created Docker containers and networks are removed when vehicle creation fails.