### PR TITLE
Validate malformed config structures

### DIFF
--- a/configmodels.py
+++ b/configmodels.py
@@ -12,15 +12,57 @@ class ConfigError(Exception):
     """Raised when a config file is missing required fields."""
 
 
+def _field_path(prefix: str, key: str) -> str:
+    return f"{prefix}.{key}" if prefix else key
+
+
+def _require_mapping(
+        data: Any,
+        filepath: str,
+        prefix: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        field_path = prefix or "config root"
+        raise ConfigError(f"{filepath}: {field_path} must be an object")
+    return data
+
+
 def _require(
         data: dict[str, Any],
         key: str,
         filepath: str,
         prefix: str) -> Any:
     if key not in data or data[key] is None:
-        field_path = f"{prefix}.{key}" if prefix else key
+        field_path = _field_path(prefix, key)
         raise ConfigError(f"{filepath}: {field_path} is required")
     return data[key]
+
+
+def _require_list(
+        data: dict[str, Any],
+        key: str,
+        filepath: str,
+        prefix: str) -> list[Any]:
+    value = _require(data, key, filepath, prefix)
+    if not isinstance(value, list):
+        field_path = _field_path(prefix, key)
+        raise ConfigError(f"{filepath}: {field_path} must be a list")
+    return value
+
+
+def _as_float(value: Any, filepath: str, field_path: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(
+            f"{filepath}: {field_path} must be a number") from exc
+
+
+def _as_int(value: Any, filepath: str, field_path: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(
+            f"{filepath}: {field_path} must be an integer") from exc
 
 
 @dataclass
@@ -37,9 +79,15 @@ class BaseLocation:
             filepath: str,
             prefix: str) -> BaseLocation:
         """Build from a raw dict, raising ConfigError on missing fields."""
+        data = _require_mapping(data, filepath, prefix)
         lat = _require(data, 'latitude', filepath, prefix)
         lon = _require(data, 'longitude', filepath, prefix)
-        return cls(latitude=float(lat), longitude=float(lon))
+        return cls(
+            latitude=_as_float(lat, filepath, _field_path(prefix, 'latitude')),
+            longitude=_as_float(
+                lon,
+                filepath,
+                _field_path(prefix, 'longitude')))
 
 
 @dataclass
@@ -59,6 +107,7 @@ class AssetConfig:
             filepath: str,
             prefix: str) -> AssetConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
+        data = _require_mapping(data, filepath, prefix)
         name = _require(data, 'name', filepath, prefix)
         type_ = _require(data, 'type', filepath, prefix)
         org = _require(data, 'organization', filepath, prefix)
@@ -70,7 +119,10 @@ class AssetConfig:
             name=str(name),
             type=str(type_),
             organization=str(org),
-            response_time_mins=int(rtm),
+            response_time_mins=_as_int(
+                rtm,
+                filepath,
+                _field_path(prefix, 'responseTimeMins')),
             base_location=base_location,
         )
 
@@ -81,6 +133,28 @@ class POIConfig:
 
     name: str
     location: dict[str, float]
+
+    @classmethod
+    def from_dict(
+            cls,
+            data: dict[str, Any],
+            filepath: str,
+            prefix: str) -> POIConfig:
+        """Build from a raw dict, raising ConfigError on invalid POIs."""
+        data = _require_mapping(data, filepath, prefix)
+        name = _require(data, 'name', filepath, prefix)
+        location_data = _require(data, 'location', filepath, prefix)
+        location = BaseLocation.from_dict(
+            location_data,
+            filepath,
+            f"{prefix}.location")
+        return cls(
+            name=str(name),
+            location={
+                'latitude': location.latitude,
+                'longitude': location.longitude,
+            },
+        )
 
 
 @dataclass
@@ -95,22 +169,21 @@ class MissionConfig:
     @classmethod
     def from_dict(cls, data: dict[str, Any], filepath: str) -> MissionConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
+        data = _require_mapping(data, filepath, '')
         name = _require(data, 'name', filepath, '')
         description = _require(data, 'description', filepath, '')
-        assets_data = _require(data, 'assets', filepath, '')
+        assets_data = _require_list(data, 'assets', filepath, '')
         assets = [
             AssetConfig.from_dict(a, filepath, f"assets[{i}]")
             for i, a in enumerate(assets_data)
         ]
         pois = []
-        if data.get('POIs'):
-            for poi in data['POIs']:
-                if isinstance(poi, dict) \
-                        and 'name' in poi and 'location' in poi:
-                    pois.append(POIConfig(
-                        name=poi['name'],
-                        location=poi['location'],
-                    ))
+        if data.get('POIs') is not None:
+            pois_data = _require_list(data, 'POIs', filepath, '')
+            pois = [
+                POIConfig.from_dict(poi, filepath, f"POIs[{i}]")
+                for i, poi in enumerate(pois_data)
+            ]
         return cls(
             name=str(name),
             description=str(description),
@@ -133,6 +206,7 @@ class MemberConfig:
             filepath: str,
             prefix: str) -> MemberConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
+        data = _require_mapping(data, filepath, prefix)
         username = _require(data, 'username', filepath, prefix)
         password = _require(data, 'password', filepath, prefix)
         return cls(username=str(username), password=str(password))
@@ -151,8 +225,9 @@ class ParticipantConfig:
             data: dict[str, Any],
             filepath: str) -> ParticipantConfig:
         """Build from a raw dict, raising ConfigError on missing fields."""
+        data = _require_mapping(data, filepath, '')
         name = _require(data, 'name', filepath, '')
-        members_data = _require(data, 'members', filepath, '')
+        members_data = _require_list(data, 'members', filepath, '')
         members = [
             MemberConfig.from_dict(m, filepath, f"members[{i}]")
             for i, m in enumerate(members_data)

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -69,6 +69,28 @@ class TestLoadConfig:
         with pytest.raises(FileNotFoundError):
             load_config(str(tmp_path / "nonexistent.yaml"))
 
+    def test_empty_yaml_raises_config_error(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text("", encoding="utf-8")
+        with pytest.raises(ConfigError, match="config root must be an object"):
+            load_config(str(path))
+
+    def test_scalar_yaml_raises_config_error(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "cfg.yaml", "not a mapping")
+        with pytest.raises(ConfigError, match="config root must be an object"):
+            load_config(path)
+
+    def test_scalar_json_raises_config_error(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        path = _write(tmp_path, "cfg.json", ["not", "a", "mapping"])
+        with pytest.raises(ConfigError, match="config root must be an object"):
+            load_config(path)
+
 
 class TestLoadMissionConfig:
     def test_valid_mission(self, tmp_path: pathlib.Path) -> None:
@@ -105,6 +127,20 @@ class TestLoadMissionConfig:
         with pytest.raises(ConfigError, match="assets is required"):
             load_mission_config(path)
 
+    def test_assets_must_be_list(self, tmp_path: pathlib.Path) -> None:
+        data = dict(MINIMAL_MISSION, assets={})
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(ConfigError, match="assets must be a list"):
+            load_mission_config(path)
+
+    def test_asset_must_be_object(self, tmp_path: pathlib.Path) -> None:
+        data = dict(MINIMAL_MISSION, assets=["not an asset"])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(
+                ConfigError,
+                match=r"assets\[0\] must be an object"):
+            load_mission_config(path)
+
     def test_missing_asset_base_location_raises(
             self,
             tmp_path: pathlib.Path) -> None:
@@ -116,6 +152,53 @@ class TestLoadMissionConfig:
         data = dict(MINIMAL_MISSION, assets=[asset])
         path = _write(tmp_path, "mission.yaml", data)
         with pytest.raises(ConfigError, match="baseLocation is required"):
+            load_mission_config(path)
+
+    def test_asset_response_time_must_be_integer(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        asset = dict(MINIMAL_MISSION["assets"][0])  # type: ignore
+        asset["responseTimeMins"] = "soon"
+        data = dict(MINIMAL_MISSION, assets=[asset])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(
+                ConfigError,
+                match=r"assets\[0\].responseTimeMins must be an integer"):
+            load_mission_config(path)
+
+    def test_asset_base_location_latitude_must_be_number(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        asset = dict(MINIMAL_MISSION["assets"][0])  # type: ignore
+        asset["baseLocation"] = {
+            "latitude": "south",
+            "longitude": 172.6,
+        }
+        data = dict(MINIMAL_MISSION, assets=[asset])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(
+                ConfigError,
+                match=r"assets\[0\].baseLocation.latitude must be a number"):
+            load_mission_config(path)
+
+    def test_pois_must_be_list(self, tmp_path: pathlib.Path) -> None:
+        data = dict(MINIMAL_MISSION, POIs={})
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(ConfigError, match="POIs must be a list"):
+            load_mission_config(path)
+
+    def test_poi_must_be_object(self, tmp_path: pathlib.Path) -> None:
+        data = dict(MINIMAL_MISSION, POIs=["not a poi"])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(ConfigError, match=r"POIs\[0\] must be an object"):
+            load_mission_config(path)
+
+    def test_poi_location_is_required(self, tmp_path: pathlib.Path) -> None:
+        data = dict(MINIMAL_MISSION, POIs=[{"name": "Clue 1"}])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(
+                ConfigError,
+                match=r"POIs\[0\].location is required"):
             load_mission_config(path)
 
     def test_json_mission(self, tmp_path: pathlib.Path) -> None:
@@ -136,6 +219,20 @@ class TestLoadParticipantConfig:
         data = {"name": "Team Alpha"}
         path = _write(tmp_path, "participant.yaml", data)
         with pytest.raises(ConfigError, match="members is required"):
+            load_participant_config(path)
+
+    def test_members_must_be_list(self, tmp_path: pathlib.Path) -> None:
+        data = {"name": "Team Alpha", "members": {}}
+        path = _write(tmp_path, "participant.yaml", data)
+        with pytest.raises(ConfigError, match="members must be a list"):
+            load_participant_config(path)
+
+    def test_member_must_be_object(self, tmp_path: pathlib.Path) -> None:
+        data = {"name": "Team Alpha", "members": ["alice"]}
+        path = _write(tmp_path, "participant.yaml", data)
+        with pytest.raises(
+                ConfigError,
+                match=r"members\[0\] must be an object"):
             load_participant_config(path)
 
     def test_member_missing_password_raises(


### PR DESCRIPTION
## Summary by Sourcery

Strengthen configuration loading to validate malformed structures and provide clearer error messages for invalid mission and participant configs.

Enhancements:
- Validate that top-level and nested config sections are mappings and that numeric fields are correctly typed, raising descriptive ConfigError messages.
- Introduce structured parsing for POI configs via a dedicated POIConfig dataclass to enforce required fields and types.

Tests:
- Add tests covering non-mapping root configs, non-list collection fields, non-object items, missing POI locations, and invalid numeric types in mission and participant configs.