### PR TITLE
Run mypy in check-code

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -6,8 +6,9 @@ pip install -r requirements-dev.txt
 
 pycodestyle *.py */*.py
 
-PYTHONPATH=`pwd` pylint services/ letsgo.py instance.py mission.py
+export PYTHONPATH=`pwd`
 
+pylint services/ letsgo.py instance.py mission.py
 mypy .
 
 pytest -m "not integration"

--- a/check-code.sh
+++ b/check-code.sh
@@ -8,4 +8,6 @@ pycodestyle *.py */*.py
 
 PYTHONPATH=`pwd` pylint services/ letsgo.py instance.py mission.py
 
+mypy .
+
 pytest -m "not integration"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
-pytest==8.3.5
+pytest==9.0.3
 pytest-mock==3.14.0
+types-PyYAML==6.0.12.20260518

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML==6.0.3
 # code checking
 pycodestyle==2.14.0
 pylint==4.0.6
+mypy==1.19.1


### PR DESCRIPTION
## Summary by Sourcery

Add static type checking to the code quality script.

Build:
- Include mypy as a dependency in requirements.txt for static type checking.

CI:
- Extend the local code check script to run mypy alongside existing linters and tests.