### PR TITLE
Move code quality tools to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
+-r requirements.txt
+pycodestyle==2.14.0
+pylint==4.0.6
+mypy==1.19.1
 pytest==9.0.3
 pytest-mock==3.14.0
 types-PyYAML==6.0.12.20260518

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,3 @@
 docker==7.1.0
 smm-client==0.0.16
 PyYAML==6.0.3
-
-# code checking
-pycodestyle==2.14.0
-pylint==4.0.6
-mypy==1.19.1


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove pycodestyle, pylint, and mypy from the production requirements file.