### PR TITLE
Validate SMM startup prerequisites

### DIFF
--- a/services/smm.py
+++ b/services/smm.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Any
 import urllib.error
 import urllib.request
 
@@ -108,6 +109,38 @@ class SMMServer:
             raise
         log.debug("SMM %s web server is ready", self.name)
 
+    def _ensure_image_available(self) -> None:
+        try:
+            self.docker_client.images.get(self.IMAGE)
+        except docker.errors.ImageNotFound as exc:
+            raise RuntimeError(
+                f"{self.IMAGE} must be pulled before starting SMM "
+                f"{self.name}") from exc
+
+    def _resolve_host_port(self) -> int:
+        if self.instance is None:
+            raise RuntimeError(f"SMM {self.name} container has not been created")
+
+        ports = self.instance.attrs.get('NetworkSettings', {}).get('Ports', {})
+        binding_key = f'{self.internal_port}/tcp'
+        bindings: Any = ports.get(binding_key)
+        if not isinstance(bindings, list) or not bindings:
+            raise RuntimeError(
+                f"SMM {self.name} has no host port binding for {binding_key}")
+
+        first_binding = bindings[0]
+        if not isinstance(first_binding, dict) or 'HostPort' not in first_binding:
+            raise RuntimeError(
+                f"SMM {self.name} has an invalid host port binding "
+                f"for {binding_key}")
+
+        try:
+            return int(first_binding['HostPort'])
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"SMM {self.name} host port binding for {binding_key} "
+                "is not an integer") from exc
+
     def start(self) -> None:
         """
         Start this instance, and the related database server.
@@ -116,6 +149,7 @@ class SMMServer:
         assert self.postgres is not None
         assert self.db_net is not None
         log.info("Starting SMM %s", self.name)
+        self._ensure_image_available()
         self.postgres.start()
         self.instance = self.docker_client.containers.create(
             self.IMAGE,
@@ -140,9 +174,7 @@ class SMMServer:
         log.debug("Created SMM container %s", self.name)
         self.instance.start()
         self.instance.reload()
-        port_bindings = self.instance.attrs['NetworkSettings']['Ports']
-        self.port = int(
-            port_bindings[f'{self.internal_port}/tcp'][0]['HostPort'])
+        self.port = self._resolve_host_port()
         log.debug("SMM %s started on port %s", self.name, self.port)
         self._wait_for_web_startup()
         log.info("SMM %s ready on port %s", self.name, self.port)

--- a/services/smm.py
+++ b/services/smm.py
@@ -119,17 +119,25 @@ class SMMServer:
 
     def _resolve_host_port(self) -> int:
         if self.instance is None:
-            raise RuntimeError(f"SMM {self.name} container has not been created")
+            raise RuntimeError(
+                f"SMM {self.name} container has not been created")
 
-        ports = self.instance.attrs.get('NetworkSettings', {}).get('Ports', {})
+        ports = self.instance.attrs.get(
+            'NetworkSettings', {}).get('Ports', {})
         binding_key = f'{self.internal_port}/tcp'
         bindings: Any = ports.get(binding_key)
         if not isinstance(bindings, list) or not bindings:
             raise RuntimeError(
                 f"SMM {self.name} has no host port binding for {binding_key}")
+        if len(bindings) != 1:
+            raise RuntimeError(
+                f"SMM {self.name} has multiple host port bindings "
+                f"for {binding_key}")
 
         first_binding = bindings[0]
-        if not isinstance(first_binding, dict) or 'HostPort' not in first_binding:
+        if (
+                not isinstance(first_binding, dict)
+                or 'HostPort' not in first_binding):
             raise RuntimeError(
                 f"SMM {self.name} has an invalid host port binding "
                 f"for {binding_key}")

--- a/tests/test_smm.py
+++ b/tests/test_smm.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for SMM server startup helpers.
+"""
+
+from unittest.mock import MagicMock
+
+import docker.errors
+import pytest
+
+from services.smm import SMMServer
+
+
+def _server() -> SMMServer:
+    server = object.__new__(SMMServer)
+    server.name = "team-alpha-smm"
+    server.internal_port = 8080
+    server.instance = MagicMock()
+    server.docker_client = MagicMock()
+    return server
+
+
+def test_ensure_image_available_checks_local_image() -> None:
+    server = _server()
+
+    server._ensure_image_available()
+
+    server.docker_client.images.get.assert_called_once_with(SMMServer.IMAGE)
+
+
+def test_ensure_image_available_raises_clear_error() -> None:
+    server = _server()
+    server.docker_client.images.get.side_effect = docker.errors.ImageNotFound(
+        "missing")
+
+    with pytest.raises(RuntimeError, match="must be pulled before starting"):
+        server._ensure_image_available()
+
+
+def test_resolve_host_port_reads_docker_binding() -> None:
+    server = _server()
+    server.instance.attrs = {
+        "NetworkSettings": {
+            "Ports": {
+                "8080/tcp": [{"HostPort": "32768"}],
+            },
+        },
+    }
+
+    assert server._resolve_host_port() == 32768
+
+
+def test_resolve_host_port_rejects_missing_binding() -> None:
+    server = _server()
+    server.instance.attrs = {
+        "NetworkSettings": {
+            "Ports": {},
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="no host port binding"):
+        server._resolve_host_port()
+
+
+def test_resolve_host_port_rejects_invalid_binding() -> None:
+    server = _server()
+    server.instance.attrs = {
+        "NetworkSettings": {
+            "Ports": {
+                "8080/tcp": [{"HostPort": "not-a-port"}],
+            },
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="is not an integer"):
+        server._resolve_host_port()

--- a/tests/test_smm.py
+++ b/tests/test_smm.py
@@ -3,6 +3,7 @@ Unit tests for SMM server startup helpers.
 """
 
 from unittest.mock import MagicMock
+from typing import cast
 
 import docker.errors
 import pytest
@@ -38,7 +39,8 @@ def test_ensure_image_available_raises_clear_error() -> None:
 
 def test_resolve_host_port_reads_docker_binding() -> None:
     server = _server()
-    server.instance.attrs = {
+    instance = cast(MagicMock, server.instance)
+    instance.attrs = {
         "NetworkSettings": {
             "Ports": {
                 "8080/tcp": [{"HostPort": "32768"}],
@@ -49,9 +51,18 @@ def test_resolve_host_port_reads_docker_binding() -> None:
     assert server._resolve_host_port() == 32768
 
 
+def test_resolve_host_port_raises_when_instance_missing() -> None:
+    server = _server()
+    server.instance = None
+
+    with pytest.raises(RuntimeError, match="container has not been created"):
+        server._resolve_host_port()
+
+
 def test_resolve_host_port_rejects_missing_binding() -> None:
     server = _server()
-    server.instance.attrs = {
+    instance = cast(MagicMock, server.instance)
+    instance.attrs = {
         "NetworkSettings": {
             "Ports": {},
         },
@@ -61,9 +72,28 @@ def test_resolve_host_port_rejects_missing_binding() -> None:
         server._resolve_host_port()
 
 
+def test_resolve_host_port_rejects_multiple_bindings() -> None:
+    server = _server()
+    instance = cast(MagicMock, server.instance)
+    instance.attrs = {
+        "NetworkSettings": {
+            "Ports": {
+                "8080/tcp": [
+                    {"HostPort": "32768"},
+                    {"HostPort": "32769"},
+                ],
+            },
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="multiple host port bindings"):
+        server._resolve_host_port()
+
+
 def test_resolve_host_port_rejects_invalid_binding() -> None:
     server = _server()
-    server.instance.attrs = {
+    instance = cast(MagicMock, server.instance)
+    instance.attrs = {
         "NetworkSettings": {
             "Ports": {
                 "8080/tcp": [{"HostPort": "not-a-port"}],


### PR DESCRIPTION
## Summary by Sourcery

Validate SMM Docker startup prerequisites and make host port resolution more robust

Bug Fixes:
- Prevent SMM startup when the Docker image is missing by raising a clear error.
- Handle missing or malformed Docker port bindings when resolving the SMM host port instead of assuming a valid mapping.

Tests:
- Add unit tests for SMM image availability checks and host port resolution error handling.