### PR TITLE
Tighten config numeric and POI validation

### DIFF
--- a/configmodels.py
+++ b/configmodels.py
@@ -50,6 +50,9 @@ def _require_list(
 
 
 def _as_float(value: Any, filepath: str, field_path: str) -> float:
+    if isinstance(value, bool):
+        raise ConfigError(
+            f"{filepath}: {field_path} must be a number, not a boolean")
     try:
         return float(value)
     except (TypeError, ValueError) as exc:
@@ -58,6 +61,9 @@ def _as_float(value: Any, filepath: str, field_path: str) -> float:
 
 
 def _as_int(value: Any, filepath: str, field_path: str) -> int:
+    if isinstance(value, bool):
+        raise ConfigError(
+            f"{filepath}: {field_path} must be an integer, not a boolean")
     try:
         return int(value)
     except (TypeError, ValueError) as exc:
@@ -132,7 +138,7 @@ class POIConfig:
     """A point of interest in a mission."""
 
     name: str
-    location: dict[str, float]
+    location: BaseLocation
 
     @classmethod
     def from_dict(
@@ -148,13 +154,7 @@ class POIConfig:
             location_data,
             filepath,
             f"{prefix}.location")
-        return cls(
-            name=str(name),
-            location={
-                'latitude': location.latitude,
-                'longitude': location.longitude,
-            },
-        )
+        return cls(name=str(name), location=location)
 
 
 @dataclass

--- a/mission.py
+++ b/mission.py
@@ -306,15 +306,9 @@ class MissionRunnerParticipant:
         Add a POI to a mission
         """
         location = poi.location
-        if not isinstance(location, dict):
-            return False
-        point = None
-        if 'latitude' in location and 'longitude' in location:
-            point = SMMPoint(location['latitude'], location['longitude'])
-        if point is not None:
-            mission.add_waypoint(point, poi.name)
-            return True
-        return False
+        point = SMMPoint(location.latitude, location.longitude)
+        mission.add_waypoint(point, poi.name)
+        return True
 
     def _get_smm_imt_challenge(self) -> SMMConnection:
         """

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -4,7 +4,6 @@ Unit tests for configloader.
 
 import json
 import pathlib
-import textwrap
 
 import pytest
 import yaml
@@ -17,21 +16,21 @@ from configloader import (
 from configmodels import ConfigError
 
 
-MINIMAL_MISSION = {
-    "name": "Test Mission",
-    "description": "A test",
-    "assets": [
-        {
-            "name": "Alpha Boat",
-            "type": "Boat",
-            "organization": "TeamAlpha",
-            "responseTimeMins": 5,
-            "baseLocation": {"latitude": -43.5, "longitude": 172.6},
-        }
-    ],
+MINIMAL_ASSET: dict[str, object] = {
+    "name": "Alpha Boat",
+    "type": "Boat",
+    "organization": "TeamAlpha",
+    "responseTimeMins": 5,
+    "baseLocation": {"latitude": -43.5, "longitude": 172.6},
 }
 
-MINIMAL_PARTICIPANT = {
+MINIMAL_MISSION: dict[str, object] = {
+    "name": "Test Mission",
+    "description": "A test",
+    "assets": [MINIMAL_ASSET],
+}
+
+MINIMAL_PARTICIPANT: dict[str, object] = {
     "name": "Team Alpha",
     "members": [{"username": "alice", "password": "secret"}],
 }
@@ -68,6 +67,33 @@ class TestLoadConfig:
     def test_missing_file_raises(self, tmp_path: pathlib.Path) -> None:
         with pytest.raises(FileNotFoundError):
             load_config(str(tmp_path / "nonexistent.yaml"))
+
+    def test_invalid_yaml_raises_parse_error(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "invalid.yaml"
+        path.write_text("key: [unclosed", encoding="utf-8")
+
+        with pytest.raises(yaml.YAMLError):
+            load_config(str(path))
+
+    def test_invalid_yml_raises_parse_error(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "invalid.yml"
+        path.write_text("another: { malformed", encoding="utf-8")
+
+        with pytest.raises(yaml.YAMLError):
+            load_config(str(path))
+
+    def test_invalid_json_raises_parse_error(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "invalid.json"
+        path.write_text('{"x": [1, 2] "y": 3}', encoding="utf-8")
+
+        with pytest.raises(json.JSONDecodeError):
+            load_config(str(path))
 
     def test_empty_yaml_raises_config_error(
             self,
@@ -114,6 +140,7 @@ class TestLoadMissionConfig:
         cfg = load_mission_config(path)
         assert len(cfg.pois) == 1
         assert cfg.pois[0].name == "Clue 1"
+        assert cfg.pois[0].location.latitude == pytest.approx(-43.6)
 
     def test_missing_name_raises(self, tmp_path: pathlib.Path) -> None:
         data = {k: v for k, v in MINIMAL_MISSION.items() if k != "name"}
@@ -146,7 +173,7 @@ class TestLoadMissionConfig:
             tmp_path: pathlib.Path) -> None:
         asset = {
             k: v
-            for k, v in MINIMAL_MISSION["assets"][0].items()  # type: ignore
+            for k, v in MINIMAL_ASSET.items()
             if k != "baseLocation"
         }
         data = dict(MINIMAL_MISSION, assets=[asset])
@@ -157,7 +184,7 @@ class TestLoadMissionConfig:
     def test_asset_response_time_must_be_integer(
             self,
             tmp_path: pathlib.Path) -> None:
-        asset = dict(MINIMAL_MISSION["assets"][0])  # type: ignore
+        asset = dict(MINIMAL_ASSET)
         asset["responseTimeMins"] = "soon"
         data = dict(MINIMAL_MISSION, assets=[asset])
         path = _write(tmp_path, "mission.yaml", data)
@@ -169,7 +196,7 @@ class TestLoadMissionConfig:
     def test_asset_base_location_latitude_must_be_number(
             self,
             tmp_path: pathlib.Path) -> None:
-        asset = dict(MINIMAL_MISSION["assets"][0])  # type: ignore
+        asset = dict(MINIMAL_ASSET)
         asset["baseLocation"] = {
             "latitude": "south",
             "longitude": 172.6,
@@ -179,6 +206,37 @@ class TestLoadMissionConfig:
         with pytest.raises(
                 ConfigError,
                 match=r"assets\[0\].baseLocation.latitude must be a number"):
+            load_mission_config(path)
+
+    def test_asset_response_time_rejects_boolean(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        asset = dict(MINIMAL_ASSET)
+        asset["responseTimeMins"] = True
+        data = dict(MINIMAL_MISSION, assets=[asset])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(
+                ConfigError,
+                match=(
+                    r"assets\[0\].responseTimeMins must be an integer, "
+                    "not a boolean")):
+            load_mission_config(path)
+
+    def test_asset_base_location_latitude_rejects_boolean(
+            self,
+            tmp_path: pathlib.Path) -> None:
+        asset = dict(MINIMAL_ASSET)
+        asset["baseLocation"] = {
+            "latitude": False,
+            "longitude": 172.6,
+        }
+        data = dict(MINIMAL_MISSION, assets=[asset])
+        path = _write(tmp_path, "mission.yaml", data)
+        with pytest.raises(
+                ConfigError,
+                match=(
+                    r"assets\[0\].baseLocation.latitude must be a number, "
+                    "not a boolean")):
             load_mission_config(path)
 
     def test_pois_must_be_list(self, tmp_path: pathlib.Path) -> None:

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -141,6 +141,7 @@ class TestLoadMissionConfig:
         assert len(cfg.pois) == 1
         assert cfg.pois[0].name == "Clue 1"
         assert cfg.pois[0].location.latitude == pytest.approx(-43.6)
+        assert cfg.pois[0].location.longitude == pytest.approx(172.7)
 
     def test_missing_name_raises(self, tmp_path: pathlib.Path) -> None:
         data = {k: v for k, v in MINIMAL_MISSION.items() if k != "name"}


### PR DESCRIPTION
## Summary by Sourcery

Tighten validation and typing for mission configuration assets and POIs, and extend tests to cover numeric and parse error cases.

Bug Fixes:
- Reject boolean values for integer and numeric configuration fields instead of coercing them.
- Ensure mission POI locations are always valid coordinates when added to missions.
- Raise clear parse errors for malformed YAML and JSON configuration files.

Enhancements:
- Introduce a reusable minimal asset fixture in tests to simplify asset-based mission configurations.
- Type POI locations as BaseLocation objects throughout the configuration and mission code path.

Tests:
- Add tests for malformed YAML and JSON configuration files to verify parse errors are surfaced.
- Add tests ensuring boolean values are rejected for numeric asset configuration fields.
- Extend POI tests to verify latitude handling and the stricter location typing.