### PR TITLE
Add context for invalid participant Docker names

### DIFF
--- a/instance.py
+++ b/instance.py
@@ -9,7 +9,7 @@ import logging
 import docker
 
 from configloader import load_participant_config
-from configmodels import ParticipantConfig
+from configmodels import ConfigError, ParticipantConfig
 from services.helpers import sanitize_docker_name
 from services.smm import SMMServer
 
@@ -23,7 +23,12 @@ class Participant:
     def __init__(self, filename: str) -> None:
         config: ParticipantConfig = load_participant_config(filename)
         self.name = config.name
-        self.service_name = sanitize_docker_name(config.name)
+        try:
+            self.service_name = sanitize_docker_name(config.name)
+        except ValueError as exc:
+            raise ConfigError(
+                f"{filename}: participant name {config.name!r} cannot be "
+                "used as a Docker resource name") from exc
         self.members = config.members
         self.smm: SMMServer | None = None
 

--- a/instance.py
+++ b/instance.py
@@ -28,7 +28,7 @@ class Participant:
         except ValueError as exc:
             raise ConfigError(
                 f"{filename}: participant name {config.name!r} cannot be "
-                "used as a Docker resource name") from exc
+                f"used as a Docker resource name: {exc}") from exc
         self.members = config.members
         self.smm: SMMServer | None = None
 

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -20,5 +20,9 @@ def test_invalid_participant_docker_name_has_file_context(
             ConfigError,
             match=(
                 "participant.yaml: participant name '///' cannot be used "
-                "as a Docker resource name")):
+                "as a Docker resource name: '///' must contain at least one "
+                "Docker-safe character")) as excinfo:
         Participant("participant.yaml")
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert str(excinfo.value.__cause__) == (
+        "'///' must contain at least one Docker-safe character")

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,0 +1,24 @@
+"""
+Unit tests for participant instance setup.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from configmodels import ConfigError, ParticipantConfig
+from instance import Participant
+
+
+def test_invalid_participant_docker_name_has_file_context(
+        mocker: MagicMock) -> None:
+    mocker.patch(
+        "instance.load_participant_config",
+        return_value=ParticipantConfig(name="///", members=[]))
+
+    with pytest.raises(
+            ConfigError,
+            match=(
+                "participant.yaml: participant name '///' cannot be used "
+                "as a Docker resource name")):
+        Participant("participant.yaml")


### PR DESCRIPTION
## Summary by Sourcery

Add contextual error reporting when participant names cannot be converted into valid Docker resource names.

Bug Fixes:
- Raise a ConfigError with filename context when participant Docker service name sanitization fails.

Tests:
- Add a unit test verifying that invalid participant Docker names produce a ConfigError message including the originating config filename.