### PR TITLE
Assert mission organization snapshot updates

### DIFF
--- a/tests/test_mission_logic.py
+++ b/tests/test_mission_logic.py
@@ -234,3 +234,4 @@ class TestCheckAddedOrganizations:
         participant.check_added_organizations()
 
         mock_pa.add_to_mission.assert_called_once()
+        assert participant.mission_org_list == [existing_org_mo, new_org_mo]


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add assertion to ensure participant.mission_org_list reflects both existing and newly added organizations in mission logic tests.