### PR TITLE
Preserve vehicle creation failures during cleanup

### DIFF
--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -55,7 +55,12 @@ class Vehicle:
                 lat,
                 lon)
         except Exception:  # pylint: disable=broad-exception-caught
-            self.stop()
+            try:
+                self.stop()
+            except Exception:  # pylint: disable=broad-exception-caught
+                log.exception(
+                    "Error during vehicle cleanup after failed creation: %s",
+                    name)
             raise
         log.debug("Created vehicle containers for %s", name)
 
@@ -130,7 +135,9 @@ class Vehicle:
             detach=True,
             name=f'{self.prefix_name}_smm_mavlink')
         self.net.connect(self.smm_mavlink)
-        assert smm_server.db_net is not None
+        if smm_server.db_net is None:
+            raise RuntimeError(
+                f"SMM server {smm_server.name} has no database network")
         smm_server.db_net.connect(self.smm_mavlink)
 
     def start(self) -> None:
@@ -138,9 +145,15 @@ class Vehicle:
         Start the vehicle
         """
         log.info("Starting vehicle %s", self.prefix_name)
-        assert self.apm is not None
-        assert self.mavproxy is not None
-        assert self.smm_mavlink is not None
+        if self.apm is None:
+            raise RuntimeError(
+                f"Vehicle {self.prefix_name} has no SITL container")
+        if self.mavproxy is None:
+            raise RuntimeError(
+                f"Vehicle {self.prefix_name} has no MAVProxy container")
+        if self.smm_mavlink is None:
+            raise RuntimeError(
+                f"Vehicle {self.prefix_name} has no SMM MAVLink container")
         self.apm.start()
         self.mavproxy.start()
         self.smm_mavlink.start()

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -40,3 +40,36 @@ def test_vehicle_constructor_cleans_up_partial_create(
     apm.remove.assert_called_once_with(force=True)
     mavproxy.remove.assert_called_once_with(force=True)
     net.remove.assert_called_once_with()
+
+
+def test_vehicle_constructor_preserves_create_failure_when_cleanup_fails(
+        mocker: MagicMock) -> None:
+    docker_client = MagicMock()
+    net = MagicMock()
+    docker_client.networks.get.side_effect = docker.errors.NotFound("missing")
+    docker_client.networks.create.return_value = net
+    docker_client.containers.create.return_value = MagicMock()
+    original_error = docker.errors.APIError("pull failed")
+    docker_client.images.pull.side_effect = original_error
+    mocker.patch(
+        "services.vehicle.docker.from_env",
+        return_value=docker_client)
+    mocker.patch(
+        "services.vehicle.remove_container",
+        side_effect=RuntimeError("cleanup failed"))
+
+    with pytest.raises(docker.errors.APIError) as excinfo:
+        Vehicle("Alpha Boat", "Rover", _smm_server(), "user", "pass")
+
+    assert excinfo.value is original_error
+
+
+def test_vehicle_start_requires_created_containers() -> None:
+    vehicle = object.__new__(Vehicle)
+    vehicle.prefix_name = "team-alpha"
+    vehicle.apm = None
+    vehicle.mavproxy = MagicMock()
+    vehicle.smm_mavlink = MagicMock()
+
+    with pytest.raises(RuntimeError, match="no SITL container"):
+        vehicle.start()


### PR DESCRIPTION
## Summary by Sourcery

Handle vehicle creation and startup failures more robustly and add tests to cover these scenarios

Bug Fixes:
- Preserve the original vehicle creation error when cleanup during construction fails
- Fail vehicle startup with clear errors when required containers are missing
- Prevent connecting the SMM MAVLink container when the SMM server lacks a database network

Tests:
- Add tests ensuring vehicle constructor preserves the original creation failure if cleanup raises an error
- Add a test verifying vehicle start raises when the SITL container is not created