### PR TITLE
Replace runtime asserts with explicit errors

### DIFF
--- a/instance.py
+++ b/instance.py
@@ -44,7 +44,8 @@ class Participant:
         """
         Setup the participant(s) accounts in this instance
         """
-        assert self.smm is not None
+        if self.smm is None:
+            raise RuntimeError(f"Participant {self.name} has not been started")
         log.info("Setting up accounts for participant %s", self.name)
         smm_admin = self.smm.get_web_connection()
         imt_org = smm_admin.create_organization('IMT')

--- a/instance.py
+++ b/instance.py
@@ -16,6 +16,10 @@ from services.smm import SMMServer
 log = logging.getLogger(__name__)
 
 
+class ServiceNotStartedError(RuntimeError):
+    """Raised when a participant service is used before startup."""
+
+
 class Participant:
     """
     State for a participant
@@ -44,10 +48,9 @@ class Participant:
         """
         Setup the participant(s) accounts in this instance
         """
-        if self.smm is None:
-            raise RuntimeError(f"Participant {self.name} has not been started")
+        smm = require_smm(self)
         log.info("Setting up accounts for participant %s", self.name)
-        smm_admin = self.smm.get_web_connection()
+        smm_admin = smm.get_web_connection()
         imt_org = smm_admin.create_organization('IMT')
         for member in self.members:
             user = smm_admin.create_user(
@@ -76,3 +79,13 @@ class Participant:
             self.smm.cleanup()
             self.smm = None
         log.debug("Participant %s cleanup complete", self.name)
+
+
+def require_smm(participant: Participant) -> SMMServer:
+    """
+    Return a participant's SMM service, or raise if it has not been started.
+    """
+    if participant.smm is None:
+        raise ServiceNotStartedError(
+            f"Participant {participant.name} has not been started")
+    return participant.smm

--- a/letsgo.py
+++ b/letsgo.py
@@ -17,7 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 import docker
 
 from configmodels import ConfigError
-from instance import Participant
+from instance import Participant, require_smm
 from mission import MissionRunner
 from services.helpers import pull_images
 from services.log import configure_logging
@@ -46,12 +46,6 @@ def _install_signal_handlers() -> None:
         raise KeyboardInterrupt(f"Received signal {signum}")
     signal.signal(signal.SIGINT, _handle)
     signal.signal(signal.SIGTERM, _handle)
-
-
-def _require_smm(participant: Participant) -> SMMServer:
-    if participant.smm is None:
-        raise RuntimeError(f"Participant {participant.name} has not been started")
-    return participant.smm
 
 
 if __name__ == "__main__":
@@ -129,7 +123,7 @@ if __name__ == "__main__":
 
         # Add each participant to the runner (serial — touches shared state)
         for participant in participant_services:
-            runner.add_participant(_require_smm(participant))
+            runner.add_participant(require_smm(participant))
 
         # Setup participant accounts in parallel
         with ThreadPoolExecutor(max_workers=n_workers) as ex:
@@ -140,7 +134,7 @@ if __name__ == "__main__":
         runner.create_mission()
 
         for participant in participant_services:
-            smm = _require_smm(participant)
+            smm = require_smm(participant)
             log.info(
                 "%s: http://localhost:%s",
                 participant.name,

--- a/letsgo.py
+++ b/letsgo.py
@@ -48,6 +48,12 @@ def _install_signal_handlers() -> None:
     signal.signal(signal.SIGTERM, _handle)
 
 
+def _require_smm(participant: Participant) -> SMMServer:
+    if participant.smm is None:
+        raise RuntimeError(f"Participant {participant.name} has not been started")
+    return participant.smm
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog='imt-challenge-runner',
@@ -123,8 +129,7 @@ if __name__ == "__main__":
 
         # Add each participant to the runner (serial — touches shared state)
         for participant in participant_services:
-            assert participant.smm is not None
-            runner.add_participant(participant.smm)
+            runner.add_participant(_require_smm(participant))
 
         # Setup participant accounts in parallel
         with ThreadPoolExecutor(max_workers=n_workers) as ex:
@@ -135,11 +140,11 @@ if __name__ == "__main__":
         runner.create_mission()
 
         for participant in participant_services:
-            assert participant.smm is not None
+            smm = _require_smm(participant)
             log.info(
                 "%s: http://localhost:%s",
                 participant.name,
-                participant.smm.port)
+                smm.port)
 
         log.info("Ready. Lets go")
 

--- a/services/postgres.py
+++ b/services/postgres.py
@@ -95,7 +95,9 @@ class PostgresServer:
         """
         Start this instance
         """
-        assert self.instance is not None
+        if self.instance is None:
+            raise RuntimeError(
+                f"Postgres {self.name} container has not been created")
         log.info("Starting postgres %s", self.name)
         self.instance.start()
         self._wait_for_startup()

--- a/services/smm.py
+++ b/services/smm.py
@@ -154,8 +154,10 @@ class SMMServer:
         Start this instance, and the related database server.
         Images are pre-pulled by the caller; only postgres startup runs here.
         """
-        assert self.postgres is not None
-        assert self.db_net is not None
+        if self.postgres is None:
+            raise RuntimeError(f"SMM {self.name} has no postgres server")
+        if self.db_net is None:
+            raise RuntimeError(f"SMM {self.name} has no database network")
         log.info("Starting SMM %s", self.name)
         self._ensure_image_available()
         self.postgres.start()

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from configmodels import ConfigError, ParticipantConfig
-from instance import Participant
+from instance import Participant, ServiceNotStartedError, require_smm
 
 
 def test_invalid_participant_docker_name_has_file_context(
@@ -26,3 +26,22 @@ def test_invalid_participant_docker_name_has_file_context(
     assert isinstance(excinfo.value.__cause__, ValueError)
     assert str(excinfo.value.__cause__) == (
         "'///' must contain at least one Docker-safe character")
+
+
+def test_require_smm_returns_started_service() -> None:
+    participant = object.__new__(Participant)
+    participant.name = "Team Alpha"
+    participant.smm = MagicMock()
+
+    assert require_smm(participant) is participant.smm
+
+
+def test_require_smm_raises_specific_error_when_not_started() -> None:
+    participant = object.__new__(Participant)
+    participant.name = "Team Alpha"
+    participant.smm = None
+
+    with pytest.raises(
+            ServiceNotStartedError,
+            match="Participant Team Alpha has not been started"):
+        require_smm(participant)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Raise descriptive RuntimeError exceptions instead of relying on assertions when participant SMM servers, SMM postgres servers, database networks, or postgres containers are missing.