### PR TITLE
Avoid sharing Docker clients during startup

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -48,9 +48,23 @@ def _install_signal_handlers() -> None:
     signal.signal(signal.SIGTERM, _handle)
 
 
-def _start_participant(participant: Participant) -> None:
-    docker_client = docker.from_env()
-    participant.start(docker_client)
+def _start_participant(participant_service: Participant) -> None:
+    try:
+        participant_client = docker.from_env()
+    except Exception:  # pylint: disable=broad-exception-caught
+        log.exception(
+            "Failed to create Docker client for participant %s",
+            participant_service.name)
+        raise
+    try:
+        participant_service.start(participant_client)
+    except Exception:  # pylint: disable=broad-exception-caught
+        log.exception(
+            "Failed to start participant %s",
+            participant_service.name)
+        raise
+    finally:
+        participant_client.close()
 
 
 if __name__ == "__main__":

--- a/letsgo.py
+++ b/letsgo.py
@@ -48,6 +48,11 @@ def _install_signal_handlers() -> None:
     signal.signal(signal.SIGTERM, _handle)
 
 
+def _start_participant(participant: Participant) -> None:
+    docker_client = docker.from_env()
+    participant.start(docker_client)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog='imt-challenge-runner',
@@ -116,7 +121,7 @@ if __name__ == "__main__":
         # Start all participant services in parallel
         with ThreadPoolExecutor(max_workers=n_workers) as ex:
             futures = [
-                ex.submit(p.start, docker_client) for p in participant_services
+                ex.submit(_start_participant, p) for p in participant_services
             ]
             for f in futures:
                 f.result()

--- a/services/helpers.py
+++ b/services/helpers.py
@@ -138,6 +138,7 @@ def wait_until(
 def pull_images(client: docker.DockerClient, images: list[str]) -> None:
     """
     Pull all images in parallel. Blocks until all pulls complete.
+    The shared Docker client is only used for independent image pull calls.
     """
     if not images:
         log.debug("No images to pull")

--- a/services/vehicle.py
+++ b/services/vehicle.py
@@ -62,6 +62,8 @@ class Vehicle:
                     "Error during vehicle cleanup after failed creation: %s",
                     name)
             raise
+        finally:
+            docker_client.close()
         log.debug("Created vehicle containers for %s", name)
 
     # pylint: disable=R0913,R0917

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for challenge startup helpers.
+"""
+
+from unittest.mock import MagicMock
+
+import docker
+import pytest
+
+import letsgo
+
+
+def test_start_participant_closes_docker_client(
+        mocker: MagicMock) -> None:
+    docker_client = MagicMock()
+    participant = MagicMock()
+    participant.name = "Team Alpha"
+    mocker.patch("letsgo.docker.from_env", return_value=docker_client)
+
+    letsgo._start_participant(participant)
+
+    participant.start.assert_called_once_with(docker_client)
+    docker_client.close.assert_called_once_with()
+
+
+def test_start_participant_closes_docker_client_after_failure(
+        mocker: MagicMock) -> None:
+    docker_client = MagicMock()
+    participant = MagicMock()
+    participant.name = "Team Alpha"
+    participant.start.side_effect = RuntimeError("start failed")
+    mocker.patch("letsgo.docker.from_env", return_value=docker_client)
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        letsgo._start_participant(participant)
+
+    docker_client.close.assert_called_once_with()
+
+
+def test_start_participant_surfaces_docker_client_failure(
+        mocker: MagicMock) -> None:
+    participant = MagicMock()
+    participant.name = "Team Alpha"
+    mocker.patch(
+        "letsgo.docker.from_env",
+        side_effect=docker.errors.DockerException("daemon unavailable"))
+
+    with pytest.raises(
+            docker.errors.DockerException,
+            match="daemon unavailable"):
+        letsgo._start_participant(participant)
+
+    participant.start.assert_not_called()

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -40,6 +40,7 @@ def test_vehicle_constructor_cleans_up_partial_create(
     apm.remove.assert_called_once_with(force=True)
     mavproxy.remove.assert_called_once_with(force=True)
     net.remove.assert_called_once_with()
+    docker_client.close.assert_called_once_with()
 
 
 def test_vehicle_constructor_preserves_create_failure_when_cleanup_fails(
@@ -62,6 +63,21 @@ def test_vehicle_constructor_preserves_create_failure_when_cleanup_fails(
         Vehicle("Alpha Boat", "Rover", _smm_server(), "user", "pass")
 
     assert excinfo.value is original_error
+    docker_client.close.assert_called_once_with()
+
+
+def test_vehicle_constructor_closes_docker_client(
+        mocker: MagicMock) -> None:
+    docker_client = MagicMock()
+    docker_client.networks.get.return_value = MagicMock()
+    docker_client.containers.create.return_value = MagicMock()
+    mocker.patch(
+        "services.vehicle.docker.from_env",
+        return_value=docker_client)
+
+    Vehicle("Alpha Boat", "Rover", _smm_server(), "user", "pass")
+
+    docker_client.close.assert_called_once_with()
 
 
 def test_vehicle_start_requires_created_containers() -> None:


### PR DESCRIPTION
## Summary by Sourcery

Start participant services with separate Docker clients to avoid sharing a client across threads during startup.

Enhancements:
- Introduce a helper to create a fresh Docker client per participant when starting services in parallel.
- Clarify documentation that the shared Docker client is only used for independent image pull operations.