### PR TITLE
Log Docker stop API failures

### DIFF
--- a/services/postgres.py
+++ b/services/postgres.py
@@ -111,8 +111,13 @@ class PostgresServer:
             return
         try:
             self.instance.stop()
-        except (docker.errors.NotFound, docker.errors.APIError):
+        except docker.errors.NotFound:
             pass
+        except docker.errors.APIError:
+            log.debug(
+                "Failed to stop postgres %s",
+                self.name,
+                exc_info=True)
 
     def cleanup(self) -> None:
         """

--- a/services/smm.py
+++ b/services/smm.py
@@ -196,8 +196,13 @@ class SMMServer:
         if self.instance is not None:
             try:
                 self.instance.stop()
-            except (docker.errors.NotFound, docker.errors.APIError):
+            except docker.errors.NotFound:
                 pass
+            except docker.errors.APIError:
+                log.debug(
+                    "Failed to stop SMM %s",
+                    self.name,
+                    exc_info=True)
         if self.postgres is not None:
             self.postgres.stop()
 


### PR DESCRIPTION
## Summary by Sourcery

Improve observability when stopping Docker-backed services by logging API failures instead of silently ignoring them.

Enhancements:
- Log Docker APIError exceptions when stopping the Postgres Docker container.
- Log Docker APIError exceptions when stopping the SMM Docker container while still ignoring NotFound errors.